### PR TITLE
Rich requests

### DIFF
--- a/examples/ha_proxy.conf
+++ b/examples/ha_proxy.conf
@@ -1,0 +1,34 @@
+input {
+  http_poller {
+    urls => {
+      haproxy => {
+        method => get
+        url => "http://A_Username:YourPassword@localhost:9201/haproxy?stats;csv"
+      }
+    }
+    request_timeout => 60
+    interval => 60
+    codec => "plain" # This is CSV data, so just let it be plain for now
+    metadata_target => "_http_poller_metadata"
+  }
+}
+
+filter {
+  split {
+  }
+
+  csv {
+    columns => [ pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt,comp_in,comp_out,comp_byp,comp_rsp,lastsess,last_chk,last_agt,qtime,ctime,rtime,ttime ]
+  }
+
+  # This is a pointless CSV header
+  if [pxname] == "# pxname" {
+    drop{}
+  }
+}
+
+output {
+  stdout {
+    codec => rubydebug
+  }
+}

--- a/examples/ha_proxy.conf
+++ b/examples/ha_proxy.conf
@@ -3,7 +3,11 @@ input {
     urls => {
       haproxy => {
         method => get
-        url => "http://A_Username:YourPassword@localhost:9201/haproxy?stats;csv"
+        url => "http://localhost:9201/haproxy?stats;csv"
+        auth => {
+          user => "myuser"
+          password => "mypass"
+        }
       }
     }
     request_timeout => 60

--- a/examples/local_elasticsearch.conf
+++ b/examples/local_elasticsearch.conf
@@ -1,0 +1,26 @@
+input {
+  http_poller {
+    urls => {
+      test1 => "http://localhost:9200"
+      test2 => {
+        # Supports all options supported by ruby's Manticore HTTP client
+        method => get
+        url => "http://localhost:9200/_cluster/health"
+        headers => {
+          Accept => "application/json"
+        }
+      }
+    }
+    request_timeout => 60
+    interval => 60
+    codec => "json"
+    # A hash of request metadata info (timing, response headers, etc.) will be sent here
+    metadata_target => "_http_poller_metadata"
+  }
+}
+
+output {
+  stdout {
+    codec => rubydebug
+  }
+}

--- a/examples/local_elasticsearch.conf
+++ b/examples/local_elasticsearch.conf
@@ -9,6 +9,10 @@ input {
         headers => {
           Accept => "application/json"
         }
+        auth => {
+          user => "AzureDiamond"
+          pass => "hunter2"
+        }
       }
     }
     request_timeout => 60

--- a/examples/local_elasticsearch.conf
+++ b/examples/local_elasticsearch.conf
@@ -24,7 +24,5 @@ input {
 }
 
 output {
-  stdout {
-    codec => rubydebug
-  }
+  elasticsearch {}
 }

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -13,24 +13,23 @@ require "manticore"
 # input {
 #   http_poller {
 #     urls => {
-#       "test1" => "http://localhost:9200"
-#     "test2" => "http://localhost:9200/_cluster/health"
-#   }
-#   request_timeout => 60
-#   interval => 10
-#   codec => "json"
-# }
-# }
-#
-# # This plugin uses metadata, which by default is not serialized
-# # You'll need a filter like this to preserve the poller metadata
-# # This metadata includes the name, url, response time, headers, and other goodies.
-# filter {
-#   mutate {
-#     add_field => [ "_http_poller_metadata", "%{[@metadata][http_poller]}" ]
+#       test1 => "http://localhost:9200"
+#     test2 => {
+#       # Supports all options supported by ruby's Manticore HTTP client
+#       method => get
+#     url => "http://localhost:9200/_cluster/health"
+#     headers => {
+#       Accept => "application/json"
+#     }
 #   }
 # }
-#
+# request_timeout => 60
+# interval => 60
+# codec => "json"
+# # A hash of request metadata info (timing, response headers, etc.) will be sent here
+# metadata_target => "_http_poller_metadata"
+# }
+# }
 #
 # output {
 #   stdout {

--- a/logstash-input-http-poller.gemspec
+++ b/logstash-input-http-poller.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.5.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 0.0.1"
+  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 1.0.0"
   s.add_runtime_dependency 'stud'
   s.add_runtime_dependency 'manticore'
   

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -39,10 +39,10 @@ describe LogStash::Inputs::HTTP_Poller do
 
     describe "#run_once" do
       it "should issue an async request for each url" do
-        default_urls.each { |name, url|
+        default_urls.each do |name, url|
           normalized_url = subject.send(:normalize_request, url)
           expect(subject).to receive(:request_async).with(queue, name, normalized_url).once
-        }
+        end
 
         subject.send(:run_once, queue) # :run_once is a private method
       end
@@ -81,12 +81,12 @@ describe LogStash::Inputs::HTTP_Poller do
           let(:spec_method) { "post" }
           let(:spec_opts) { {:"X-Bender" => "Je Suis Napoleon!"} }
 
-          let(:url) {
+          let(:url) do
             {
               "url" => spec_url,
               "method" => spec_method,
             }.merge(Hash[spec_opts.map {|k,v| [k.to_s,v]}])
-          }
+          end
 
           include_examples("a normalized request")
         end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -25,10 +25,6 @@ describe LogStash::Inputs::HTTP_Poller do
 
   subject { klass.new(default_opts) }
 
-  before do
-    #subject.register
-  end
-
   describe "#run" do
     it "should run at the specified interval" do
       expect(Stud).to receive(:interval).with(default_interval).once

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -23,280 +23,272 @@ describe LogStash::Inputs::HTTP_Poller do
   }
   let(:klass) { LogStash::Inputs::HTTP_Poller }
 
-  subject {
-    s = klass.new(default_opts)
-    s.register # We can't use a before block here because of rspec scoping
-    s
-  }
-
-  describe "#run" do
-    it "should run at the specified interval" do
-      expect(Stud).to receive(:interval).with(default_interval).once
-      subject.run(double("queue"))
-    end
-  end
-
-  describe "#run_once" do
-    it "should issue an async request for each url" do
-      default_urls.each { |name, url|
-        normalized_url = subject.send(:normalize_request, url)
-        expect(subject).to receive(:request_async).with(queue, name, normalized_url).once
-      }
-
-      subject.send(:run_once, queue) # :run_once is a private method
-    end
-  end
-
-  shared_examples("matching metadata") {
-    let(:metadata) { event[metadata_target] }
-
-    it "should have the correct name" do
-      expect(metadata["name"]).to eql(name)
-    end
-
-    it "should have the correct url" do
-      expect(metadata["url"]).to eql(url)
-    end
-
-    it "should have the correct code" do
-      expect(metadata["code"]).to eql(code)
-    end
-  }
-
-  shared_examples "unprocessable_requests" do
-    let(:poller) { LogStash::Inputs::HTTP_Poller.new(settings) }
-    subject(:event) {
-      poller.send(:run_once, queue)
-      queue.pop(true)
-    }
+  describe "instances" do
+    subject { klass.new(default_opts) }
 
     before do
-      poller.register
-      allow(poller).to receive(:handle_failure).and_call_original
-      allow(poller).to receive(:handle_success)
-      event # materialize the subject
+      subject.register
     end
 
-    it "should enqueue a message" do
-      expect(event).to be_a(LogStash::Event)
-    end
-
-    it "should enqueue a message with '_http_request_failure' set" do
-      expect(event["_http_request_failure"]).to be_a(Hash)
-    end
-
-    it "should tag the event with '_http_request_failure'" do
-      expect(event["tags"]).to include('_http_request_failure')
-    end
-
-    it "should invoke handle failure exactly once" do
-      expect(poller).to have_received(:handle_failure).once
-    end
-
-    it "should not invoke handle success at all" do
-      expect(poller).not_to have_received(:handle_success)
-    end
-
-    include_examples("matching metadata")
-  end
-
-  context "with a non responsive server" do
-    context "due to a non-existant host" do # Fail with handlers
-      let(:name) { default_name }
-      let(:url) { "http://thouetnhoeu89ueoueohtueohtneuohn" }
-      let(:code) { nil } # no response expected
-
-      let(:settings) { default_opts.merge("urls" => { name => url}) }
-
-      include_examples("unprocessable_requests")
-    end
-
-    context "due to a bogus port number" do # fail with return?
-      let(:invalid_port) { Flores::Random.integer(65536..1000000) }
-
-      let(:name) { default_name }
-      let(:url) { "http://127.0.0.1:#{invalid_port}" }
-      let(:settings) { default_opts.merge("urls" => {name => url}) }
-      let(:code) { nil } # No response expected
-
-      include_examples("unprocessable_requests")
-    end
-  end
-
-  describe "a codec mismatch" do
-    let(:instance) { klass.new(default_opts) }
-    before do
-      instance.register
-    end
-    subject(:qmsg) {
-      queue.pop(true)
-    }
-
-    before do
-      instance.client.stub(default_url,
-                           :body => "Definitely not JSON!",
-                           :code => 200
-      )
-      instance.send(:run_once, queue)
-    end
-
-    it "should send a _jsonparsefailure" do
-      expect(qmsg["tags"]).to include("_jsonparsefailure")
-    end
-  end
-
-  describe "a valid request and decoded response" do
-    let(:payload) { {"a" => 2, "hello" => ["a", "b", "c"]} }
-    let(:opts) { default_opts }
-    let(:instance) {
-      klass.new(opts)
-    }
-    let(:name) { default_name }
-    let(:url) { default_url }
-    let(:code) { 202 }
-
-    subject(:event) {
-      queue.pop(true)
-    }
-
-    before do
-      instance.register
-      u = url.is_a?(Hash) ? url["url"] : url # handle both complex specs and simple string URLs
-      instance.client.stub(u,
-                           :body => LogStash::Json.dump(payload),
-                           :code => code
-      )
-      instance.send(:run_once, queue)
-    end
-
-    it "should have a matching message" do
-      expect(event.to_hash).to include(payload)
-    end
-
-    include_examples("matching metadata")
-
-    context "with metadata omitted" do
-      let(:opts) {
-        opts = default_opts.clone
-        opts.delete("metadata_target")
-        opts
-      }
-
-      it "should not have any metadata on the event" do
-        instance.send(:run_once, queue)
-        expect(event[metadata_target]).to be_nil
+    describe "#run" do
+      it "should run at the specified interval" do
+        expect(Stud).to receive(:interval).with(default_interval).once
+        subject.run(double("queue"))
       end
     end
 
-    context "with a complex URL spec" do
-      let(:url) {
-        {
-          "method" => "get",
-          "url" => default_url,
-          "headers" => {
-            "X-Fry" => "I'm having one of those things, like a headache, with pictures..."
-          }
+    describe "#run_once" do
+      it "should issue an async request for each url" do
+        default_urls.each { |name, url|
+          normalized_url = subject.send(:normalize_request, url)
+          expect(subject).to receive(:request_async).with(queue, name, normalized_url).once
         }
-      }
-      let(:opts) {
-        {
-          "interval" => default_interval,
-          "urls" => {
-            default_name => url
-          },
-          "codec" => "json",
-          "metadata_target" => metadata_target
-        }
-      }
 
-      include_examples("matching metadata")
-
-      it "should have a matching message" do
-        expect(event.to_hash).to include(payload)
-      end
-    end
-  end
-
-  describe "normalizing a request spec" do
-    shared_examples "a normalized request" do
-      it "should set the method correctly" do
-        expect(normalized.first).to eql(spec_method.to_sym)
-      end
-
-      it "should set the options to the URL string" do
-        expect(normalized[1]).to eql(spec_url)
-      end
-
-      it "should to set additional options correctly" do
-        opts = normalized.length > 2 ? normalized[2] : nil
-        expect(opts).to eql(spec_opts)
+        subject.send(:run_once, queue) # :run_once is a private method
       end
     end
 
-    let(:normalized) { subject.send(:normalize_request, url) }
+    describe "normalizing a request spec" do
+      shared_examples "a normalized request" do
+        it "should set the method correctly" do
+          expect(normalized.first).to eql(spec_method.to_sym)
+        end
 
-    describe "a string URL" do
-      let(:url) { "http://localhost:3000" }
-      let(:spec_url) { url }
-      let(:spec_method) { :get }
-      let(:spec_opts) { nil }
+        it "should set the options to the URL string" do
+          expect(normalized[1]).to eql(spec_url)
+        end
 
-      include_examples("a normalized request")
-    end
+        it "should to set additional options correctly" do
+          opts = normalized.length > 2 ? normalized[2] : nil
+          expect(opts).to eql(spec_opts)
+        end
+      end
 
-    describe "URL specs" do
-      context "with basic opts" do
-        let(:spec_url) { "http://localhost:3000" }
-        let(:spec_method) { "post" }
-        let(:spec_opts) { {:"X-Bender" => "Je Suis Napoleon!"} }
+      let(:normalized) { subject.send(:normalize_request, url) }
 
-        let(:url) {
-          {
-            "url" => spec_url,
-            "method" => spec_method,
-          }.merge(Hash[spec_opts.map {|k,v| [k.to_s,v]}])
-        }
+      describe "a string URL" do
+        let(:url) { "http://localhost:3000" }
+        let(:spec_url) { url }
+        let(:spec_method) { :get }
+        let(:spec_opts) { nil }
 
         include_examples("a normalized request")
       end
 
-      context "missing an URL" do
-        let(:url) { {"method" => "get"} }
+      describe "URL specs" do
+        context "with basic opts" do
+          let(:spec_url) { "http://localhost:3000" }
+          let(:spec_method) { "post" }
+          let(:spec_opts) { {:"X-Bender" => "Je Suis Napoleon!"} }
 
-        it "should raise an error" do
-          expect { normalized }.to raise_error(LogStash::ConfigurationError)
+          let(:url) {
+            {
+              "url" => spec_url,
+              "method" => spec_method,
+            }.merge(Hash[spec_opts.map {|k,v| [k.to_s,v]}])
+          }
+
+          include_examples("a normalized request")
         end
-      end
 
-      describe "auth" do
-        let(:url) { {"url" => "http://localhost", "method" => "get", "auth" => auth} }
-
-        context "with auth enabled but no pass" do
-          let(:auth) { {"user" => "foo"} }
+        context "missing an URL" do
+          let(:url) { {"method" => "get"} }
 
           it "should raise an error" do
             expect { normalized }.to raise_error(LogStash::ConfigurationError)
           end
         end
 
-        context "with auth enabled, a path, but no user" do
-          let(:url) { {"method" => "get", "auth" => {"pass" => "bar"}} }
-          it "should raise an error" do
-            expect { normalized }.to raise_error(LogStash::ConfigurationError)
-          end
-        end
-        context "with auth enabled correctly" do
-          let(:auth) { {"user" => "foo", "pass" => "bar"} }
+        describe "auth" do
+          let(:url) { {"url" => "http://localhost", "method" => "get", "auth" => auth} }
 
-          it "should raise an error" do
-            expect { normalized }.not_to raise_error
+          context "with auth enabled but no pass" do
+            let(:auth) { {"user" => "foo"} }
+
+            it "should raise an error" do
+              expect { normalized }.to raise_error(LogStash::ConfigurationError)
+            end
           end
 
-          it "should properly set the auth parameter" do
-            expect(normalized[2][:auth]).to eql({:user => auth["user"], :pass => auth["pass"]})
+          context "with auth enabled, a path, but no user" do
+            let(:url) { {"method" => "get", "auth" => {"pass" => "bar"}} }
+            it "should raise an error" do
+              expect { normalized }.to raise_error(LogStash::ConfigurationError)
+            end
+          end
+          context "with auth enabled correctly" do
+            let(:auth) { {"user" => "foo", "pass" => "bar"} }
+
+            it "should raise an error" do
+              expect { normalized }.not_to raise_error
+            end
+
+            it "should properly set the auth parameter" do
+              expect(normalized[2][:auth]).to eql({:user => auth["user"], :pass => auth["pass"]})
+            end
           end
         end
       end
     end
   end
+
+  describe "events" do
+    shared_examples("matching metadata") {
+      let(:metadata) { event[metadata_target] }
+
+      it "should have the correct name" do
+        expect(metadata["name"]).to eql(name)
+      end
+
+      it "should have the correct url" do
+        expect(metadata["url"]).to eql(url)
+      end
+
+      it "should have the correct code" do
+        expect(metadata["code"]).to eql(code)
+      end
+    }
+
+    shared_examples "unprocessable_requests" do
+      let(:poller) { LogStash::Inputs::HTTP_Poller.new(settings) }
+      subject(:event) {
+        poller.send(:run_once, queue)
+        queue.pop(true)
+      }
+
+      before do
+        poller.register
+        allow(poller).to receive(:handle_failure).and_call_original
+        allow(poller).to receive(:handle_success)
+        event # materialize the subject
+      end
+
+      it "should enqueue a message" do
+        expect(event).to be_a(LogStash::Event)
+      end
+
+      it "should enqueue a message with '_http_request_failure' set" do
+        expect(event["_http_request_failure"]).to be_a(Hash)
+      end
+
+      it "should tag the event with '_http_request_failure'" do
+        expect(event["tags"]).to include('_http_request_failure')
+      end
+
+      it "should invoke handle failure exactly once" do
+        expect(poller).to have_received(:handle_failure).once
+      end
+
+      it "should not invoke handle success at all" do
+        expect(poller).not_to have_received(:handle_success)
+      end
+
+      include_examples("matching metadata")
+    end
+
+    context "with a non responsive server" do
+      context "due to a non-existant host" do # Fail with handlers
+        let(:name) { default_name }
+        let(:url) { "http://thouetnhoeu89ueoueohtueohtneuohn" }
+        let(:code) { nil } # no response expected
+
+        let(:settings) { default_opts.merge("urls" => { name => url}) }
+
+        include_examples("unprocessable_requests")
+      end
+
+      context "due to a bogus port number" do # fail with return?
+        let(:invalid_port) { Flores::Random.integer(65536..1000000) }
+
+        let(:name) { default_name }
+        let(:url) { "http://127.0.0.1:#{invalid_port}" }
+        let(:settings) { default_opts.merge("urls" => {name => url}) }
+        let(:code) { nil } # No response expected
+
+        include_examples("unprocessable_requests")
+      end
+    end
+
+
+    describe "a valid request and decoded response" do
+      let(:payload) { {"a" => 2, "hello" => ["a", "b", "c"]} }
+      let(:opts) { default_opts }
+      let(:instance) {
+        klass.new(opts)
+      }
+      let(:name) { default_name }
+      let(:url) { default_url }
+      let(:code) { 202 }
+
+      subject(:event) {
+        queue.pop(true)
+      }
+
+      before do
+        instance.register
+        u = url.is_a?(Hash) ? url["url"] : url # handle both complex specs and simple string URLs
+        instance.client.stub(u,
+                             :body => LogStash::Json.dump(payload),
+                             :code => code
+        )
+        instance.send(:run_once, queue)
+      end
+
+      it "should have a matching message" do
+        expect(event.to_hash).to include(payload)
+      end
+
+      include_examples("matching metadata")
+
+      context "with metadata omitted" do
+        let(:opts) {
+          opts = default_opts.clone
+          opts.delete("metadata_target")
+          opts
+        }
+
+        it "should not have any metadata on the event" do
+          instance.send(:run_once, queue)
+          expect(event[metadata_target]).to be_nil
+        end
+      end
+
+      context "with a complex URL spec" do
+        let(:url) {
+          {
+            "method" => "get",
+            "url" => default_url,
+            "headers" => {
+              "X-Fry" => "I'm having one of those things, like a headache, with pictures..."
+            }
+          }
+        }
+        let(:opts) {
+          {
+            "interval" => default_interval,
+            "urls" => {
+              default_name => url
+            },
+            "codec" => "json",
+            "metadata_target" => metadata_target
+          }
+        }
+
+        include_examples("matching metadata")
+
+        it "should have a matching message" do
+          expect(event.to_hash).to include(payload)
+        end
+      end
+    end
+  end
+
+
+
+
+
+
+
+
+
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -111,20 +111,20 @@ describe LogStash::Inputs::HTTP_Poller do
           end
 
           context "with auth enabled, a path, but no user" do
-            let(:url) { {"method" => "get", "auth" => {"pass" => "bar"}} }
+            let(:url) { {"method" => "get", "auth" => {"password" => "bar"}} }
             it "should raise an error" do
               expect { normalized }.to raise_error(LogStash::ConfigurationError)
             end
           end
           context "with auth enabled correctly" do
-            let(:auth) { {"user" => "foo", "pass" => "bar"} }
+            let(:auth) { {"user" => "foo", "password" => "bar"} }
 
             it "should raise an error" do
               expect { normalized }.not_to raise_error
             end
 
             it "should properly set the auth parameter" do
-              expect(normalized[2][:auth]).to eql({:user => auth["user"], :pass => auth["pass"]})
+              expect(normalized[2][:auth]).to eql({:user => auth["user"], :pass => auth["password"]})
             end
           end
         end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -255,9 +255,37 @@ describe LogStash::Inputs::HTTP_Poller do
         let(:url) { {"method" => "get"} }
 
         it "should raise an error" do
-          expect {
-            normalized
-          }.to raise_error(ArgumentError)
+          expect { normalized }.to raise_error(LogStash::ConfigurationError)
+        end
+      end
+
+      describe "auth" do
+        let(:url) { {"url" => "http://localhost", "method" => "get", "auth" => auth} }
+
+        context "with auth enabled but no pass" do
+          let(:auth) { {"user" => "foo"} }
+
+          it "should raise an error" do
+            expect { normalized }.to raise_error(LogStash::ConfigurationError)
+          end
+        end
+
+        context "with auth enabled, a path, but no user" do
+          let(:url) { {"method" => "get", "auth" => {"pass" => "bar"}} }
+          it "should raise an error" do
+            expect { normalized }.to raise_error(LogStash::ConfigurationError)
+          end
+        end
+        context "with auth enabled correctly" do
+          let(:auth) { {"user" => "foo", "pass" => "bar"} }
+
+          it "should raise an error" do
+            expect { normalized }.not_to raise_error
+          end
+
+          it "should properly set the auth parameter" do
+            expect(normalized[2][:auth]).to eql({:user => auth["user"], :pass => auth["pass"]})
+          end
         end
       end
     end


### PR DESCRIPTION
This supports a rich request syntax

You can now specify complex requests in addition to simple ones. For example

```
input {
  http_poller {
    urls => {
      test1 => "http://localhost:9200"
      test2 => {
        # Supports all options supported by ruby's Manticore HTTP client
        method => get
        url => "http://localhost:9200/_cluster/health"
        headers => {
          Accept => "application/json"
        }
      }
    }
    request_timeout => 60
    interval => 60
    codec => "json"
    # A hash of request metadata info (timing, response headers, etc.) will be sent here
    metadata_target => "_http_poller_metadata"
  }
}
```


Fixes https://github.com/logstash-plugins/logstash-input-http_poller/issues/5
As well as https://github.com/logstash-plugins/logstash-input-http_poller/issues/4