### PR TITLE
Normalize requests in metadata

### DIFF
--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -31,7 +31,7 @@ require "manticore"
 #     interval => 60
 #     codec => "json"
 #     # A hash of request metadata info (timing, response headers, etc.) will be sent here
-#     metadata_target => "_http_poller_metadata"
+#     metadata_target => "http_poller_metadata"
 #   }
 # }
 #
@@ -183,8 +183,8 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
     # This is also in the metadata, but we send it anyone because we want this
     # persisted by default, whereas metadata isn't. People don't like mysterious errors
-    event["_http_request_failure"] = {
-      "url" => @urls[name], # We want the exact parameter they passed in
+    event["http_request_failure"] = {
+      "request" => structure_request(request),
       "name" => name,
       "error" => exception.to_s,
       "backtrace" => exception.backtrace,
@@ -213,7 +213,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     m = {
         "name" => name,
         "host" => @host,
-        "url" => @urls[name]
+        "request" => structure_request(request),
       }
 
     m["runtime_seconds"] = execution_time
@@ -226,5 +226,16 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     end
 
     m
+  end
+
+  private
+  # Turn [method, url, spec] requests into a hash for friendlier logging / ES indexing
+  def structure_request(request)
+    method, url, spec = request
+    # Flatten everything into the 'spec' hash, also stringify any keys to normalize
+    Hash[(spec||{}).merge({
+      "method" => method.to_s,
+      "url" => url,
+    }).map {|k,v| [k.to_s,v] }]
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -130,6 +130,25 @@ describe LogStash::Inputs::HTTP_Poller do
         end
       end
     end
+
+    describe "#structure_request" do
+      it "Should turn a simple request into the expected structured request" do
+        expected = {"url" => "http://example.net", "method" => "get"}
+        expect(subject.send(:structure_request, ["get", "http://example.net"])).to eql(expected)
+      end
+
+      it "should turn a complex request into the expected structured one" do
+        headers = {
+          "X-Fry" => " Like a balloon, and... something bad happens! "
+        }
+        expected = {
+          "url" => "http://example.net",
+          "method" => "get",
+          "headers" => headers
+        }
+        expect(subject.send(:structure_request, ["get", "http://example.net", {"headers" => headers}])).to eql(expected)
+      end
+    end
   end
 
   describe "events" do

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -140,8 +140,12 @@ describe LogStash::Inputs::HTTP_Poller do
         expect(metadata["name"]).to eql(name)
       end
 
-      it "should have the correct url" do
-        expect(metadata["url"]).to eql(url)
+      it "should have the correct request url" do
+        if url.is_a?(Hash) # If the url was specified as a complex test the whole thing
+          expect(metadata["request"]).to eql(url)
+        else # Otherwise we have to make some assumptions
+          expect(metadata["request"]["url"]).to eql(url)
+        end
       end
 
       it "should have the correct code" do
@@ -167,8 +171,8 @@ describe LogStash::Inputs::HTTP_Poller do
         expect(event).to be_a(LogStash::Event)
       end
 
-      it "should enqueue a message with '_http_request_failure' set" do
-        expect(event["_http_request_failure"]).to be_a(Hash)
+      it "should enqueue a message with 'http_request_failure' set" do
+        expect(event["http_request_failure"]).to be_a(Hash)
       end
 
       it "should tag the event with '_http_request_failure'" do


### PR DESCRIPTION
This patch ensures that regardless of whether a URL is declared in the long or the short form it is normalized to the same hash. This is important when the ES output is used because you cannot have a mapping that accepts either a hash or a string for the same value (and ES will give you a very confusing error in this case).

This patch also defaults to not using _ prefixes for error metadata for better ES/Kibana compatibility as well.