### PR TITLE
No retries by default

### DIFF
--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -18,6 +18,7 @@ require "manticore"
 #         # Supports all options supported by ruby's Manticore HTTP client
 #         method => get
 #         url => "http://localhost:9200/_cluster/health"
+#         automatic_retries => 2 # Retry the URL twice
 #         headers => {
 #           Accept => "application/json"
 #         }
@@ -43,6 +44,11 @@ require "manticore"
 
 class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   include LogStash::PluginMixins::HttpClient
+
+  # Default client options for requests
+  DEFAULT_SPEC = {
+    :automatic_retries => 0 # By default manticore retries 3 times, make this explicit
+  }
 
   config_name "http_poller"
 
@@ -82,10 +88,10 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   private
   def normalize_request(url_or_spec)
     if url_or_spec.is_a?(String)
-      res = [:get, url_or_spec]
+      res = [:get, url_or_spec, DEFAULT_SPEC.clone]
     elsif url_or_spec.is_a?(Hash)
       # The client will expect keys / values
-      spec = Hash[url_or_spec.clone.map {|k,v| [k.to_sym, v] }] # symbolize keys
+      spec = Hash[DEFAULT_SPEC.merge(url_or_spec).map {|k,v| [k.to_sym, v] }] # symbolize keys
 
       # method and url aren't really part of the options, so we pull them out
       method = (spec.delete(:method) || :get).to_sym.downcase

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -90,6 +90,29 @@ describe LogStash::Inputs::HTTP_Poller do
             }.merge(Hash[spec_opts.map {|k,v| [k.to_s,v]}])
           end
 
+          it "should include the default options" do
+            expect(normalized[2]).to include(LogStash::Inputs::HTTP_Poller::DEFAULT_SPEC)
+          end
+
+          context "when overiding a spec default" do
+            let(:retries) { 3 }
+            let(:url) do
+              {
+                "url" => spec_url,
+                "method" => spec_method,
+                "automatic_retries" => retries
+              }.merge(Hash[spec_opts.map {|k,v| [k.to_s,v]}])
+            end
+
+            it "should override the default options" do
+              expect(normalized[2]).to include(:automatic_retries => retries)
+            end
+
+            it "should not include the defaults" do
+              expect(normalized[2]).not_to include(LogStash::Inputs::HTTP_Poller::DEFAULT_SPEC)
+            end
+          end
+
           include_examples("a normalized request")
         end
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -60,7 +60,9 @@ describe LogStash::Inputs::HTTP_Poller do
 
         it "should to set additional options correctly" do
           opts = normalized.length > 2 ? normalized[2] : nil
-          expect(opts).to eql(spec_opts)
+          # At this point we'r ddealing in symbols
+          expected = Hash[LogStash::Inputs::HTTP_Poller::DEFAULT_SPEC.merge(spec_opts || {}).map {|k,v| [k.to_sym,v]} ]
+          expect(opts).to eql(expected)
         end
       end
 
@@ -161,7 +163,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       it "should have the correct request url" do
         if url.is_a?(Hash) # If the url was specified as a complex test the whole thing
-          expect(metadata["request"]).to eql(url)
+          expect(metadata["request"]).to include(url)
         else # Otherwise we have to make some assumptions
           expect(metadata["request"]["url"]).to eql(url)
         end


### PR DESCRIPTION
By default manticore retries all requests 3 times. This is unexpected behavior for this application, very bad when using it to health check URLs for instance. Let's make 0 retries the default from now on, it's still overridable however.