### PR TITLE
Fix retries logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* 1.1.2
+  - Correctly default to zero connection retries
+  - Revert old ineffective code for connection retries
 * 1.1.1
   - Default to zero connection retries
 * 1.1.0

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -18,7 +18,6 @@ require "manticore"
 #         # Supports all options supported by ruby's Manticore HTTP client
 #         method => get
 #         url => "http://localhost:9200/_cluster/health"
-#         automatic_retries => 2 # Retry the URL twice
 #         headers => {
 #           Accept => "application/json"
 #         }
@@ -44,11 +43,6 @@ require "manticore"
 
 class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   include LogStash::PluginMixins::HttpClient
-
-  # Default client options for requests
-  DEFAULT_SPEC = {
-    :automatic_retries => 0 # By default manticore retries 3 times, make this explicit
-  }
 
   config_name "http_poller"
 
@@ -88,10 +82,10 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   private
   def normalize_request(url_or_spec)
     if url_or_spec.is_a?(String)
-      res = [:get, url_or_spec, DEFAULT_SPEC.clone]
+      res = [:get, url_or_spec]
     elsif url_or_spec.is_a?(Hash)
       # The client will expect keys / values
-      spec = Hash[DEFAULT_SPEC.merge(url_or_spec).map {|k,v| [k.to_sym, v] }] # symbolize keys
+      spec = Hash[url_or_spec.clone.map {|k,v| [k.to_sym, v] }] # symbolize keys
 
       # method and url aren't really part of the options, so we pull them out
       method = (spec.delete(:method) || :get).to_sym.downcase

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-input-http_poller'
-  s.version         = '1.1.1'
+  s.version         = '1.1.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Poll HTTP endpoints with Logstash."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program."
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.5.0', '< 2.0.0'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 1.0.0"
+  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 1.0.1"
   s.add_runtime_dependency 'stud'
   s.add_runtime_dependency 'manticore'
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -60,9 +60,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
         it "should to set additional options correctly" do
           opts = normalized.length > 2 ? normalized[2] : nil
-          # At this point we'r ddealing in symbols
-          expected = Hash[LogStash::Inputs::HTTP_Poller::DEFAULT_SPEC.merge(spec_opts || {}).map {|k,v| [k.to_sym,v]} ]
-          expect(opts).to eql(expected)
+          expect(opts).to eql(spec_opts)
         end
       end
 
@@ -163,7 +161,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       it "should have the correct request url" do
         if url.is_a?(Hash) # If the url was specified as a complex test the whole thing
-          expect(metadata["request"]).to include(url)
+          expect(metadata["request"]).to eql(url)
         else # Otherwise we have to make some assumptions
           expect(metadata["request"]["url"]).to eql(url)
         end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -90,29 +90,6 @@ describe LogStash::Inputs::HTTP_Poller do
             }.merge(Hash[spec_opts.map {|k,v| [k.to_s,v]}])
           end
 
-          it "should include the default options" do
-            expect(normalized[2]).to include(LogStash::Inputs::HTTP_Poller::DEFAULT_SPEC)
-          end
-
-          context "when overiding a spec default" do
-            let(:retries) { 3 }
-            let(:url) do
-              {
-                "url" => spec_url,
-                "method" => spec_method,
-                "automatic_retries" => retries
-              }.merge(Hash[spec_opts.map {|k,v| [k.to_s,v]}])
-            end
-
-            it "should override the default options" do
-              expect(normalized[2]).to include(:automatic_retries => retries)
-            end
-
-            it "should not include the defaults" do
-              expect(normalized[2]).not_to include(LogStash::Inputs::HTTP_Poller::DEFAULT_SPEC)
-            end
-          end
-
           include_examples("a normalized request")
         end
 


### PR DESCRIPTION
The old code did nothing, this reverts it, and uses an updated HTTP client mixin that actually handles this correctly.