### PR TITLE
Small changes, raise min version of http_client mixin

### DIFF
--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,11 +1,12 @@
 Gem::Specification.new do |s|
-  s.name = 'logstash-input-http_poller'
-  s.version         = '2.0.5'
-  s.licenses = ['Apache License (2.0)']
-  s.summary = "Poll HTTP endpoints with Logstash."
+  s.name        = 'logstash-input-http_poller'
+  s.version     = '2.0.6'
+  s.licenses    = ['Apache License (2.0)']
+  s.summary     = "Poll HTTP endpoints with Logstash."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program."
-  s.authors = ["andrewvc"]
-  s.homepage = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.authors     = [ "Elastic", "andrewvc"]
+  s.email       = 'info@elastic.co'
+  s.homepage    = "http://www.elastic.co/guide/en/logstash/current/index.html"
   s.require_paths = ["lib"]
 
   # Files
@@ -19,7 +20,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 2.2.1", "< 3.0.0"
+  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 2.2.4", "< 3.0.0"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
 
   s.add_development_dependency 'logstash-codec-json'


### PR DESCRIPTION
* Raise logstash-mixin-http_client min version to include the Fix broken ssl_certificate_validation flag, see https://github.com/logstash-plugins/logstash-mixin-http_client/commit/73b1a6d089fafa6df3f00b4de7781072db71307b for details
* Add elastic as an author, like in other plugins created by the core developers.