### PR TITLE
#34, use rufus-scheduler for more flexible scheduling

### DIFF
--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '3.0.3'
+  s.version         = '3.1.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Poll HTTP endpoints with Logstash."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,8 +22,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-mixin-http_client', ">= 2.2.4", "< 5.0.0"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
+  s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
 
   s.add_development_dependency 'logstash-codec-json'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'flores'
+  s.add_development_dependency 'timecop'
 end


### PR DESCRIPTION
Use rufus scheduler to support more flexible scheduling options.

It supports four different types of scheduling - cron, every, in and at.
"every" option (e.g. every 5 minutes) offers the same functionality
as existing Stud/interval scheduling. Therefore, 'interval' config
option is deprecated.

1) bumped to 3.1.0

2) Made the following interface changes to the plugin configs:
 + deprecated "interval" option
 + added "schedule" option. e.g schedule => { every => "2m"}

3) If both are specified, raise ConfigurationError.

4) Use existing Stud library if interval option is specified. Use
rufus-scheduler if schedule option is specified.

5) The first invoke of "every" schedule type is configured to run
immediately to match the semantic of interval option.

6) The first invoke of "every" schedule type in rufus-scheduler(v3.0.9)
sometimes does not run immediately, even if :first => :now is specified.
i.e sometimes the first run is invoked immediately after schedule is
started, but sometimes only after the first interval is elasped. The
issue is no longer reproducible in current version (v3.2.2). However,
I can't upgrade to v3.2.2 immediately since other logstash plugins
are using old version. So, I added a workaround that works for both
versions.
