### PR TITLE
Add eager auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+ - Use eager auth. This means the client will send any credentials in its first request
+   rather than waiting for a 401 challenge
 ## 3.1.1
  - Handle empty bodies correctly
 ## 3.1.0

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -145,8 +145,13 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
       url = spec.delete(:url)
 
       # We need these strings to be keywords!
-      spec[:auth] = {user: spec[:auth]["user"], pass: spec[:auth]["password"]} if spec[:auth]
-
+      if spec[:auth]
+        spec[:auth] = {
+          user: spec[:auth]["user"], 
+          pass: spec[:auth]["password"],
+          eager: true
+        } 
+      end
       res = [method, url, spec]
     else
       raise LogStash::ConfigurationError, "Invalid URL or request spec: '#{url_or_spec}', expected a String or Hash!"

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '3.1.1'
+  s.version         = '3.2.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Poll HTTP endpoints with Logstash."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -131,7 +131,11 @@ describe LogStash::Inputs::HTTP_Poller do
             end
 
             it "should properly set the auth parameter" do
-              expect(normalized[2][:auth]).to eql({:user => auth["user"], :pass => auth["password"]})
+              expect(normalized[2][:auth]).to eq({
+                :user => auth["user"], 
+                :pass => auth["password"],
+                :eager => true
+              })
             end
           end
         end


### PR DESCRIPTION
By default manticore will wait for a 401 challenge before sending auth headers. This makes it send the creds straight away.
