### PR TITLE
Bump http_connection/manticore deps. Cleaner auth opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 3.3.0
+ - Add top level user/password options that apply to all URLs by default.
+ - Make user/password configurable per-URL nested at the top level without the extra auth hash
+   to make them more consistent with the global opts
+ - Bump mixin-http_client version
+
 ## 3.2.0
  - Use eager auth. This means the client will send any credentials in its first request
    rather than waiting for a 401 challenge
+
 ## 3.1.1
  - Handle empty bodies correctly
 ## 3.1.0

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -37,15 +37,13 @@ input {
       test2 => {
         # Supports all options supported by ruby's Manticore HTTP client
         method => get
+        user => "AzureDiamond"
+        password => "hunter2"
         url => "http://localhost:9200/_cluster/health"
         headers => {
           Accept => "application/json"
         }
-        auth => {
-          user => "AzureDiamond"
-          password => "hunter2"
-        }
-      }
+     }
     }
     request_timeout => 60
     # Supports "cron", "every", "at" and "in" schedules by rufus scheduler
@@ -96,6 +94,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-user>> |<<string,string>>|no
+| <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-automatic_retries>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-client_cert>> |a valid filesystem path|No
@@ -128,6 +128,23 @@ Also see <<plugins-{type}s-common-options>> for a list of options supported by a
 input plugins.
 
 &nbsp;
+
+[id="plugins-{type}s-{plugin}-user"]
+===== `user` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Username to use with HTTP authentication for ALL requests. Note that you can also set this per-URL.
+If you set this you must also set the `password` option.
+
+[id="plugins-{type}s-{plugin}-password"]
+===== `password` 
+
+  * Value type is <<password,password>>
+  * There is no default value for this setting.
+
+Password to be used in conjunction with the username for HTTP authentication.
 
 [id="plugins-{type}s-{plugin}-automatic_retries"]
 ===== `automatic_retries` 

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '3.2.0'
+  s.version         = '3.3.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Poll HTTP endpoints with Logstash."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 2.2.4", "< 5.0.0"
+  s.add_runtime_dependency 'logstash-mixin-http_client', ">= 5.0.0", "< 6.0.0"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
   s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -106,9 +106,7 @@ describe LogStash::Inputs::HTTP_Poller do
           end
         end
 
-        describe "auth" do
-          let(:url) { {"url" => "http://localhost", "method" => "get", "auth" => auth} }
-
+        shared_examples "auth" do
           context "with auth enabled but no pass" do
             let(:auth) { {"user" => "foo"} }
 
@@ -138,6 +136,20 @@ describe LogStash::Inputs::HTTP_Poller do
               })
             end
           end
+        end
+
+        # Legacy way of doing things, kept for backwards compat.
+        describe "auth with nested auth hash" do
+          let(:url) { {"url" => "http://localhost", "method" => "get", "auth" => auth} }
+          
+          include_examples("auth")
+        end
+
+        # The new 'right' way to do things
+        describe "auth with direct auth options" do
+          let(:url) { {"url" => "http://localhost", "method" => "get", "user" => auth["user"], "password" => auth["password"]} }
+          
+          include_examples("auth")
         end
       end
     end


### PR DESCRIPTION
This PR bumps the http_connection mixin version and gets the latest
manticore. It also improves / cleans up the auth args. Now, there is
the ability to set the user/password at the connection level, not just
on individual URLs.

To make things more consistent the prefered way to specify the auth is
now to directly set user/password on the per-url opts rather than
nesting them under 'auth'. Both still work however for compatibility.