### PR TITLE
Remove the loggings of urls at startup

### DIFF
--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -42,8 +42,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   def register
     @host = Socket.gethostname.force_encoding(Encoding::UTF_8)
 
-    @logger.info("Registering http_poller Input", :type => @type,
-                 :urls => @urls, :schedule => @schedule, :timeout => @timeout)
+    @logger.info("Registering http_poller Input", :type => @type, :schedule => @schedule, :timeout => @timeout)
 
     setup_requests!
   end
@@ -215,9 +214,16 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
                                       :exception => e,
                                       :exception_message => e.message,
                                       :exception_backtrace => e.backtrace,
+                                      :name => name)
+
+      # If we are running in debug mode we can display more information about the
+      # specific request which could give more details about the connection.
+      @logger.debug? && @logger.debug("Cannot read URL or send the error as an event!",
+                                      :exception => e,
+                                      :exception_message => e.message,
+                                      :exception_backtrace => e.backtrace,
                                       :name => name,
-                                      :url => request
-      )
+                                      :url => request)
   end
 
   private


### PR DESCRIPTION
When Logstash was starting at the register call we were bleeding all the
urls in the log, since we want this plugins to be supported in multiple
version of logstash is to simply remove them from the logger.

We could also leak the password when an exception happen because the
response and the request where both sent to the log, we change the logic
if we are running in debug mode we will send the content to the logger.