### PR TITLE
Remove link in overview table to fix doc build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+  - Docs: Remove row in overview table to fix build error
+  
 ## 4.0.2
   - Don't bleed URLs credentials on startup and on exception #82
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -115,7 +115,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-ssl_certificate_validation>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Poll HTTP endpoints with Logstash."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When the `ssl_certificate_validation` option was removed, someone forgot to remove the link in the overview table. This PR fixes the doc build error that results.
