### PR TITLE
Remove ssl_certificate_validation option from the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.3.4
-  - Docs: Remove row in overview table to fix build error
+  - Docs: Remove ssl_certificate_validation option from the docs
 
 ## 3.3.3
  - Don't bleed URls credentials on startup or on exception #82

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.4
+  - Docs: Remove row in overview table to fix build error
+
 ## 3.3.3
  - Don't bleed URls credentials on startup or on exception #82
 
@@ -16,6 +19,7 @@
 
 ## 3.1.1
  - Handle empty bodies correctly
+
 ## 3.1.0
  - Use rufus-scheduler for more flexible scheduling. Many thanks to [@hummingV](https://github.com/hummingV) for this contribution. ([#58](https://github.com/logstash-plugins/logstash-input-http_poller/pull/58))
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -115,7 +115,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-ssl_certificate_validation>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -330,15 +330,6 @@ See: rufus/scheduler for details about different schedule options and value stri
 
 Timeout (in seconds) to wait for data on the socket. Default is `10s`
 
-[id="plugins-{type}s-{plugin}-ssl_certificate_validation"]
-===== `ssl_certificate_validation` 
-
-  * Value type is <<boolean,boolean>>
-  * Default value is `true`
-
-Set this to false to disable SSL/TLS certificate validation
-Note: setting this to false is generally considered insecure!
-
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target` 
 

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '3.3.3'
+  s.version         = '3.3.4'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Poll HTTP endpoints with Logstash."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
@ph Looks like this commit was not ported to 3.x: https://github.com/logstash-plugins/logstash-input-http_poller/commit/5f4f08876861e82ebee1af0ffa7b722135e4369e#diff-e3e2a9bfd88566b05001b02a3f51d286

I'm assuming that you want the option removed completely, so I removed it in this PR.