### PR TITLE
Update HTTP Poller Doc - Schedule Required

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -113,7 +113,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-proxy>> |<<,>>|No
 | <<plugins-{type}s-{plugin}-request_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-retry_non_idempotent>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|No
+| <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|Yes
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No


### PR DESCRIPTION
Update documentation for the Logstash HTTP Poller input as it states that the schedule is non required field, although Logstash will not start without it.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
