### PR TITLE
support line-style codecs by ensuring flush is sent with each response

### DIFF
--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -165,7 +165,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     # If there is a usable response. HEAD requests are `nil` and empty get
     # responses come up as "" which will cause the codec to not yield anything
     if body && body.size > 0
-      @codec.decode(body) do |decoded|
+      decode_and_flush(@codec, body) do |decoded|
         event = @target ? LogStash::Event.new(@target => decoded.to_hash) : decoded
         handle_decoded_event(queue, name, request, response, event, execution_time)
       end
@@ -173,6 +173,12 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
       event = ::LogStash::Event.new
       handle_decoded_event(queue, name, request, response, event, execution_time)
     end
+  end
+
+  private
+  def decode_and_flush(codec, body, &yielder)
+    codec.decode(body, &yielder)
+    codec.flush(&yielder)
   end
 
   private

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
 
   s.add_development_dependency 'logstash-codec-json'
+  s.add_development_dependency 'logstash-codec-line'
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'flores'
   s.add_development_dependency 'timecop'

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -462,6 +462,40 @@ describe LogStash::Inputs::HTTP_Poller do
           expect(event.get(target)).to include(payload_normalized)
         end
       end
+
+      context 'using a line codec' do
+        let(:opts) do
+          default_opts.merge({"codec" => "line"})
+        end
+        subject(:events) do
+          [].tap do |events|
+            events << queue.pop until queue.empty?
+          end
+        end
+
+        context 'when response has a trailing newline' do
+          let(:response_body) { "one\ntwo\nthree\nfour\n" }
+          it 'emits all events' do
+            expect(events.size).to equal(4)
+            messages = events.map{|e| e.get('message')}
+            expect(messages).to include('one')
+            expect(messages).to include('two')
+            expect(messages).to include('three')
+            expect(messages).to include('four')
+          end
+        end
+        context 'when response has no trailing newline' do
+          let(:response_body) { "one\ntwo\nthree\nfour" }
+          it 'emits all events' do
+            expect(events.size).to equal(4)
+            messages = events.map{|e| e.get('message')}
+            expect(messages).to include('one')
+            expect(messages).to include('two')
+            expect(messages).to include('three')
+            expect(messages).to include('four')
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
User `sabdoul` in the Logstash Forums reported that the last line of responses read with the line codec were not getting flushed:

> I have my last line of csv data that I get with http_poller plugin that is not imported.
> Some people have solved the problem by adding a blank newline at the end of the csv file.
> [...]
>
> -- https://discuss.elastic.co/t/logstash-filter-csv-last-row-not-reading/128005

This patch ensures that the codec is flushed at the end of each body.

An alternate approach, which would still require flushing, would be to clone the codec for each response, since responses shouldn't interleave on the codec anyway.