### PR TITLE
Update http_poller.rb

### DIFF
--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -59,6 +59,11 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   def normalize_request(url_or_spec)
     if url_or_spec.is_a?(String)
       res = [:get, url_or_spec]
+      #substitute date variables if passed as part of the URL string
+      now_datetime = DateTime.now
+      res.gsub!(/{{%y}}/, now_datetime.year)
+      res.gsub!(/{{%m}}/, now_datetime.month)
+
     elsif url_or_spec.is_a?(Hash)
       # The client will expect keys / values
       spec = Hash[url_or_spec.clone.map {|k,v| [k.to_sym, v] }] # symbolize keys

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -6,10 +6,10 @@ require "socket" # for Socket.gethostname
 require "manticore"
 require "rufus/scheduler"
 
-class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
+class LogStash::Inputs::HTTP_Poller2 < LogStash::Inputs::Base
   include LogStash::PluginMixins::HttpClient
 
-  config_name "http_poller"
+  config_name "http_poller2"
 
   default :codec, "json"
 
@@ -40,7 +40,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   def register
     @host = Socket.gethostname.force_encoding(Encoding::UTF_8)
 
-    @logger.info("Registering http_poller Input", :type => @type, :schedule => @schedule, :timeout => @timeout)
+    @logger.info("Registering http_poller2 Input", :type => @type, :schedule => @schedule, :timeout => @timeout)
 
     setup_requests!
   end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -5,7 +5,7 @@ require "timecop"
 # Workaround for the bug reported in https://github.com/jruby/jruby/issues/4637
 require 'rspec/matchers/built_in/raise_error.rb'
 
-describe LogStash::Inputs::HTTP_Poller do
+describe LogStash::Inputs::HTTP_Poller2 do
   let(:metadata_target) { "_http_poller_metadata" }
   let(:queue) { Queue.new }
   let(:default_schedule) {
@@ -26,7 +26,7 @@ describe LogStash::Inputs::HTTP_Poller do
       "metadata_target" => metadata_target
     }
   }
-  let(:klass) { LogStash::Inputs::HTTP_Poller }
+  let(:klass) { LogStash::Inputs::HTTP_Poller2 }
 
   describe "instances" do
     subject { klass.new(default_opts) }
@@ -305,7 +305,7 @@ describe LogStash::Inputs::HTTP_Poller do
     }
 
     shared_examples "unprocessable_requests" do
-      let(:poller) { LogStash::Inputs::HTTP_Poller.new(settings) }
+      let(:poller) { LogStash::Inputs::HTTP_Poller2.new(settings) }
       subject(:event) {
         poller.send(:run_once, queue)
         queue.pop(true)


### PR DESCRIPTION
Added in the ability to variable substitute dates into the URL passed. Only Year and month currently supported, but the idea can be easily expanded to support anything else required.