### PR TITLE
Added in parameter enabled timeframe support

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -117,6 +117,11 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|Yes
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-time_back_buffer_string |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-time_back_buffer |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-time_forward_buffer_string |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-time_forward_buffer |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-time_format |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-truststore_type>> |<<string,string>>|No
@@ -323,6 +328,51 @@ Timeout (in seconds) to wait for data on the socket. Default is `10s`
   * There is no default value for this setting.
 
 Define the target field for placing the received data. If this setting is omitted, the data will be stored at the root (top level) of the event.
+
+[id="plugins-{type}s-{plugin}-time_back_buffer_string"]
+=====    time_back_buffer_string
+
+  * Value type is <<string,string>>
+  * Default value is `time_back_buffer`
+
+The text to replace in the URL with a formatted time string that represents a time in the past
+
+[id="plugins-{type}s-{plugin}-time_back_buffer"]
+=====    time_back_buffer
+
+  * Value type is <<number,number>>
+  * There is no default value for this setting
+
+The time in seconds to set the 'time_back_buffer' backwards
+
+[id="plugins-{type}s-{plugin}-time_forward_buffer_string"]
+=====    time_forward_buffer_string
+
+  * Value type is <<string,string>>
+  * Default value is `time_forward_buffer`
+
+The text to replace in the URL with a formatted time string that represents a time in the future
+
+[id="plugins-{type}s-{plugin}-time_forward_buffer"]
+=====    time_forward_buffer
+
+  * Value type is <<number,number>>
+  * Default value is `0`
+
+The time in seconds to set the 'time_forward_buffer' forwards
+
+[id="plugins-{type}s-{plugin}-time_format"]
+=====    time_format
+
+  * Value type is <<string,string>>
+  * Default value is `'%s'`
+
+The string representing the ruby DateTime strftime output format.
+Examples include:
+  1. %FT%R    - 2007-11-19T08:37            Calendar date and local time (extended)
+  2. %FT%T%:z - 2007-11-19T08:37:48-06:00   Date and time of day for calendar date (extended)
+  3. %s       - Number of seconds since 1970-01-01 00:00:00 UTC.
+  4. %Q       - Number of milliseconds since 1970-01-01 00:00:00 UTC.
 
 [id="plugins-{type}s-{plugin}-truststore"]
 ===== `truststore` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -117,11 +117,11 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-schedule>> |<<hash,hash>>|Yes
 | <<plugins-{type}s-{plugin}-socket_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-time_back_buffer_string |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-time_back_buffer |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-time_forward_buffer_string |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-time_forward_buffer |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-time_format |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-time_back_buffer_string>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-time_back_buffer>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-time_forward_buffer_string>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-time_forward_buffer>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-time_format>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-truststore_type>> |<<string,string>>|No
@@ -330,7 +330,7 @@ Timeout (in seconds) to wait for data on the socket. Default is `10s`
 Define the target field for placing the received data. If this setting is omitted, the data will be stored at the root (top level) of the event.
 
 [id="plugins-{type}s-{plugin}-time_back_buffer_string"]
-=====    time_back_buffer_string
+===== `time_back_buffer_string`
 
   * Value type is <<string,string>>
   * Default value is `time_back_buffer`
@@ -338,7 +338,7 @@ Define the target field for placing the received data. If this setting is omitte
 The text to replace in the URL with a formatted time string that represents a time in the past
 
 [id="plugins-{type}s-{plugin}-time_back_buffer"]
-=====    time_back_buffer
+===== `time_back_buffer`
 
   * Value type is <<number,number>>
   * There is no default value for this setting
@@ -346,7 +346,7 @@ The text to replace in the URL with a formatted time string that represents a ti
 The time in seconds to set the 'time_back_buffer' backwards
 
 [id="plugins-{type}s-{plugin}-time_forward_buffer_string"]
-=====    time_forward_buffer_string
+===== `time_forward_buffer_string`
 
   * Value type is <<string,string>>
   * Default value is `time_forward_buffer`
@@ -354,7 +354,7 @@ The time in seconds to set the 'time_back_buffer' backwards
 The text to replace in the URL with a formatted time string that represents a time in the future
 
 [id="plugins-{type}s-{plugin}-time_forward_buffer"]
-=====    time_forward_buffer
+===== `time_forward_buffer`
 
   * Value type is <<number,number>>
   * Default value is `0`
@@ -362,7 +362,7 @@ The text to replace in the URL with a formatted time string that represents a ti
 The time in seconds to set the 'time_forward_buffer' forwards
 
 [id="plugins-{type}s-{plugin}-time_format"]
-=====    time_format
+===== `time_format`
 
   * Value type is <<string,string>>
   * Default value is `'%s'`

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -5,6 +5,7 @@ require "logstash/plugin_mixins/http_client"
 require "socket" # for Socket.gethostname
 require "manticore"
 require "rufus/scheduler"
+require "date"
 
 class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   include LogStash::PluginMixins::HttpClient
@@ -34,6 +35,23 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   # Set this value to the name of the field you'd like to store a nested
   # hash of metadata.
   config :metadata_target, :validate => :string, :default => '@metadata'
+
+  # The name of a variable to use in string replacement for time based calls in the past
+  # making available as a variable to work around hard-coded string substition issues
+  config :time_back_buffer_string, :validate => :string, :default => 'time_back_buffer'
+
+  # The amount of time in seconds to poll backwards
+  config :time_back_buffer, :validate => :number
+
+  # The name of a variable to use in string replacement for time based calls in the past
+  # making available as a variable to work around hard-coded string substition issues
+  config :time_forward_buffer_string, :validate => :string, :default => 'time_forward_buffer'
+
+  # The amount of time in seconds to poll forwards
+  config :time_forward_buffer, :validate => :number, :default => 0
+
+  # get the timeformat, to support seconds and milliseconds
+  config :time_format, :validate => ['seconds','milliseconds'], :default => 'seconds'
 
   public
   Schedule_types = %w(cron every at in)
@@ -147,7 +165,51 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   private
   def request_async(queue, name, request)
     @logger.debug? && @logger.debug("Fetching URL", :name => name, :url => request)
+    @logger.debug? && @logger.debug("Forward Buffer", :buffer => @time_back_buffer)
+    @logger.debug? && @logger.debug("Backward Buffer", :buffer => @time_forward_buffer)
+    @logger.debug? && @logger.debug("Time Format", :format => @time_format)
+    # Grab the current time
     started = Time.now
+
+    # this needs to be a DateTime to deal with subtractions
+    currenttime = DateTime.now
+    @logger.debug? && @logger.debug("Current Time", :currenttime => currenttime)
+    # If we have the @time_back_buffer set, we modify the URL with a calculated timestamp
+    back_buffer = @time_back_buffer
+    forward_buffer = @time_forward_buffer
+
+    # To support multiple formats
+    # https://apidock.com/ruby/DateTime/strftime
+    if @time_format == "seconds"
+      time_format_code = '%s'
+    elsif @time_format == "milliseconds"
+      time_format_code = '%Q'
+    end
+
+    # Deal with buffers going backwards
+    if @time_back_buffer && @time_back_buffer > 0
+      # Rational is fractions, and the second number is the number of seconds in a day
+      # Datetime is the time since the unix epoch, and it works using rational numbers
+      # https://stackoverflow.com/a/10056201 has more info
+      buffer = currenttime - Rational(back_buffer,86400)
+      @logger.debug? && @logger.debug("Back Buffer", :buffer => buffer)
+	    request[1] = request[1].gsub(/#{time_back_buffer_string}/,buffer.strftime(time_format_code))
+      #test1 = request[1].gsub(/#{time_back_buffer_string}/,back_buffer.strftime('%Q'))
+      #test2 = request[1].gsub(@time_back_buffer_string,back_buffer.strftime('%Q'))
+    end
+
+    # deal with forward buffers, if we need to
+    # We can tolerate a zero here because it would indicate 'now'
+    if @time_forward_buffer && @time_forward_buffer >= 0
+      # Rational is fractions, and the second number is the number of seconds in a day
+      # Datetime is the time since the unix epoch, and it works using rational numbers
+      # https://stackoverflow.com/a/10056201 has more info
+      buffer = currenttime + Rational(forward_buffer,86400)
+      @logger.debug? && @logger.debug("Forward Buffer", :buffer => buffer)
+	    request[1] = request[1].gsub(/#{time_forward_buffer_string}/,buffer.strftime(time_format_code))
+      #test1 = request[1].gsub(/#{time_back_buffer_string}/,back_buffer.strftime('%Q'))
+      #test2 = request[1].gsub(@time_back_buffer_string,back_buffer.strftime('%Q'))
+    end
 
     method, *request_opts = request
     client.async.send(method, *request_opts).

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -204,7 +204,10 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
             # Originally request[1] = request[1].gsub(/#{time_back_buffer_string}/,buffer.strftime(time_format_code))
             @logger.debug? && @logger.debug("URL timestamp - backwards - pre:", :url => request[i])
             request[i] = request[i].gsub(/#{time_back_buffer_string}/,buffer.strftime(time_format_code))
+            # Store the timestamp as a variable to swap it back after the URL has been fetched
+            @buffer_time_back = buffer.strftime(time_format_code)
             @logger.debug? && @logger.debug("URL timestamp - backwards - post:", :url => request[i])
+            @logger.debug? && @logger.debug("URL timestamp - backwards - string:", :time => buffer_time_back)
 		      end
 		    end
 	    end
@@ -226,7 +229,10 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
             # Originally request[1] = request[1].gsub(/#{time_forward_buffer_string}/,buffer.strftime(time_format_code))
             @logger.debug? && @logger.debug("URL timestamp - forwards - pre:", :url => request[i])
             request[i] = request[i].gsub(/#{time_forward_buffer_string}/,buffer.strftime(time_format_code))
+            # Store the timestamp as a variable to swap it back after the URL has been fetched
+            @buffer_time_forward = buffer.strftime(time_format_code)
             @logger.debug? && @logger.debug("URL timestamp - forwards - post:", :url => request[i])
+            @logger.debug? && @logger.debug("URL timestamp - forwards - string:", :time => buffer_time_forward)
 		      end
 		    end
 	    end
@@ -234,9 +240,30 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
     method, *request_opts = request
     client.async.send(method, *request_opts).
-      on_success {|response| handle_success(queue, name, request, response, Time.now - started)}.
+      on_success {|response| 
+	  @logger.debug? && @logger.debug("URL timestamp - success - pre:", :url => request[1])
+      handle_success(queue, name, request, response, Time.now - started)
+	    # If either of out buffers were set, replace the contents of the URL back to our string
+	    # It has been observed that the URL wasn't being set back, hence this workaround
+	    if @buffer_time_back
+        request[1] = request[1].gsub(@buffer_time_back,time_back_buffer_string)
+      end
+	    if @buffer_time_forward
+        request[1] = request[1].gsub(@buffer_time_forward,time_forward_buffer_string)
+      end
+      @logger.debug? && @logger.debug("URL timestamp - success - post:", :url => request[1])}.
       on_failure {|exception|
+	  @logger.debug? && @logger.debug("URL timestamp - failure - pre:", :url => request[1])
       handle_failure(queue, name, request, exception, Time.now - started)
+	    # If either of out buffers were set, replace the contents of the URL back to our string
+	    # It has been observed that the URL wasn't being set back, hence this workaround
+	    if @buffer_time_back
+        request[1] = request[1].gsub(@buffer_time_back,time_back_buffer_string)
+      end
+	    if @buffer_time_forward
+        request[1] = request[1].gsub(@buffer_time_forward,time_forward_buffer_string)
+      end
+      @logger.debug? && @logger.debug("URL timestamp - failure - post:", :url => request[1])
     }
   end
 

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -196,7 +196,18 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
       # https://stackoverflow.com/a/10056201 has more info
       buffer = currenttime - Rational(back_buffer,86400)
       @logger.debug? && @logger.debug("Back Buffer", :buffer => buffer)
-	    request[1] = request[1].gsub(/#{time_back_buffer_string}/,buffer.strftime(time_format_code))
+      request.each_with_index do |entry, i| 
+        # We need to verify we're working with a string, otherwise we run in to method not found errors 
+        if request[i].is_a? String 
+          # And lets only modify strings that actually include our text
+          if request[i].include?("#{time_back_buffer_string}")
+            # Originally request[1] = request[1].gsub(/#{time_back_buffer_string}/,buffer.strftime(time_format_code))
+            @logger.debug? && @logger.debug("URL timestamp - backwards - pre:", :url => request[i])
+            request[i] = request[i].gsub(/#{time_back_buffer_string}/,buffer.strftime(time_format_code))
+            @logger.debug? && @logger.debug("URL timestamp - backwards - post:", :url => request[i])
+		      end
+		    end
+	    end
     end
 
     # deal with forward buffers, if we need to
@@ -207,7 +218,18 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
       # https://stackoverflow.com/a/10056201 has more info
       buffer = currenttime + Rational(forward_buffer,86400)
       @logger.debug? && @logger.debug("Forward Buffer", :buffer => buffer)
-	    request[1] = request[1].gsub(/#{time_forward_buffer_string}/,buffer.strftime(time_format_code))
+	    request.each_with_index do |entry, i| 
+        # We need to verify we're working with a string, otherwise we run in to method not found errors 
+        if request[i].is_a? String 
+          # And lets only modify strings that actually include our text
+          if request[i].include?("#{time_forward_buffer_string}")
+            # Originally request[1] = request[1].gsub(/#{time_forward_buffer_string}/,buffer.strftime(time_format_code))
+            @logger.debug? && @logger.debug("URL timestamp - forwards - pre:", :url => request[i])
+            request[i] = request[i].gsub(/#{time_forward_buffer_string}/,buffer.strftime(time_format_code))
+            @logger.debug? && @logger.debug("URL timestamp - forwards - post:", :url => request[i])
+		      end
+		    end
+	    end
     end
 
     method, *request_opts = request

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -170,8 +170,8 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   private
   def request_async(queue, name, request)
     @logger.debug? && @logger.debug("Fetching URL", :name => name, :url => request)
-    @logger.debug? && @logger.debug("Forward Buffer", :buffer => @time_back_buffer)
-    @logger.debug? && @logger.debug("Backward Buffer", :buffer => @time_forward_buffer)
+    @logger.debug? && @logger.debug("Forward Buffer", :buffer => @time_forward_buffer)
+    @logger.debug? && @logger.debug("Backward Buffer", :buffer => @time_back_buffer)
     @logger.debug? && @logger.debug("Time Format", :format => @time_format)
     # Grab the current time
     started = Time.now

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -208,9 +208,9 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
             @buffer_time_back = buffer.strftime(time_format_code)
             @logger.debug? && @logger.debug("URL timestamp - backwards - post:", :url => request[i])
             @logger.debug? && @logger.debug("URL timestamp - backwards - string:", :time => buffer_time_back)
-		      end
-		    end
-	    end
+          end
+        end
+      end
     end
 
     # deal with forward buffers, if we need to
@@ -233,34 +233,34 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
             @buffer_time_forward = buffer.strftime(time_format_code)
             @logger.debug? && @logger.debug("URL timestamp - forwards - post:", :url => request[i])
             @logger.debug? && @logger.debug("URL timestamp - forwards - string:", :time => buffer_time_forward)
-		      end
-		    end
-	    end
+          end
+        end
+      end
     end
 
     method, *request_opts = request
     client.async.send(method, *request_opts).
       on_success {|response| 
-	  @logger.debug? && @logger.debug("URL timestamp - success - pre:", :url => request[1])
+    @logger.debug? && @logger.debug("URL timestamp - success - pre:", :url => request[1])
       handle_success(queue, name, request, response, Time.now - started)
-	    # If either of out buffers were set, replace the contents of the URL back to our string
-	    # It has been observed that the URL wasn't being set back, hence this workaround
-	    if @buffer_time_back
+      # If either of out buffers were set, replace the contents of the URL back to our string
+      # It has been observed that the URL wasn't being set back, hence this workaround
+      if @buffer_time_back
         request[1] = request[1].gsub(@buffer_time_back,time_back_buffer_string)
       end
-	    if @buffer_time_forward
+      if @buffer_time_forward
         request[1] = request[1].gsub(@buffer_time_forward,time_forward_buffer_string)
       end
       @logger.debug? && @logger.debug("URL timestamp - success - post:", :url => request[1])}.
       on_failure {|exception|
-	  @logger.debug? && @logger.debug("URL timestamp - failure - pre:", :url => request[1])
+    @logger.debug? && @logger.debug("URL timestamp - failure - pre:", :url => request[1])
       handle_failure(queue, name, request, exception, Time.now - started)
-	    # If either of out buffers were set, replace the contents of the URL back to our string
-	    # It has been observed that the URL wasn't being set back, hence this workaround
-	    if @buffer_time_back
+      # If either of out buffers were set, replace the contents of the URL back to our string
+      # It has been observed that the URL wasn't being set back, hence this workaround
+      if @buffer_time_back
         request[1] = request[1].gsub(@buffer_time_back,time_back_buffer_string)
       end
-	    if @buffer_time_forward
+      if @buffer_time_forward
         request[1] = request[1].gsub(@buffer_time_forward,time_forward_buffer_string)
       end
       @logger.debug? && @logger.debug("URL timestamp - failure - post:", :url => request[1])

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -56,7 +56,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   # %FT%T%:z  - 2007-11-19T08:37:48-06:00 Date and time of day for calendar date (extended)
   # %s      - Number of seconds since 1970-01-01 00:00:00 UTC.
   # %Q      - Number of milliseconds since 1970-01-01 00:00:00 UTC.
-  config :time_format, :validate => :string
+  config :time_format, :validate => :string, :default => '%s'
 
   public
   Schedule_types = %w(cron every at in)


### PR DESCRIPTION
These changes allow a user to specify a timeframe, in either seconds or milliseconds, to poll an API that requires timestamps as a parameter. Example: https://docs.umbrella.com/umbrella-api/docs/security-activity-report

Obviously I didn't change the asciidoc, nor the spec, but I approached this as solving a problem I had. 

Here's an example use:
```
  http_poller {
    urls => {
      Umbrella => {
        method => get
        url => "https://reports.api.umbrella.com/v1/organizations/[REMOVED]/security-activity?start=time_back_buffer&stop=time_forward_buffer"
        headers => {
          Accept => "application/json"
          Authorization => "Basic [REMOVED]"
        }
     }
    }
    request_timeout => 60
    # Supports "cron", "every", "at" and "in" schedules by rufus scheduler 
    schedule => { cron => "* * * * * UTC"}
    codec => "json"
    time_back_buffer_string => "time_back_buffer"
    time_back_buffer => 900
    time_forward_buffer_string => "time_forward_buffer"
    # A hash of request metadata info (timing, response headers, etc.) will be sent here
    metadata_target => "http_poller_metadata"
  }
