### PR TITLE
Do not limit scheduler library to old version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.0
+ - Do not limit scheduler library to old version [#121](https://github.com/logstash-plugins/logstash-input-http_poller/pull/121)
+
 ## 5.0.1
  - Fixed minor doc and doc formatting issues [#107](https://github.com/logstash-plugins/logstash-input-http_poller/pull/107)
 

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '5.0.1'
+  s.version         = '5.1.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-mixin-http_client', "~> 7"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
-  s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
+  s.add_runtime_dependency 'rufus-scheduler', "~> 3.0"
 
   s.add_development_dependency 'logstash-codec-json'
   s.add_development_dependency 'logstash-codec-line'


### PR DESCRIPTION
Versions prior to 3.3.3 print Fixnum warnings on Ruby >= 2.4 (LS 7.x)

The 3.0.x lock is there since it was first introduced: https://github.com/logstash-plugins/logstash-input-http_poller/commit/dd37c846c8c4dc3fa5963ce79da377012033d4b9

Other plugins such as jdbc do not have a strict limit but suffer from getting the library updated in LS.

see https://github.com/logstash-plugins/logstash-integration-jdbc/issues/21