### PR TITLE
Add ECS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.1.0
-  - Add ECS support
+  - Add ECS support [#129](https://github.com/logstash-plugins/logstash-input-http_poller/pull/129)
 
 ## 5.0.2
  - [DOC]Expanded url option to include Manticore keys [#119](https://github.com/logstash-plugins/logstash-input-http_poller/pull/119)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.0
+  - Add ECS support
+
 ## 5.0.2
  - [DOC]Expanded url option to include Manticore keys [#119](https://github.com/logstash-plugins/logstash-input-http_poller/pull/119)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -421,8 +421,8 @@ Timeout (in seconds) to wait for data on the socket. Default is `10s`
 
 Define the target field for placing the received data. If this setting is omitted, the data will be stored at the root (top level) of the event.
 
-When ECS is enabled, it is preferable to set `target` in codec, `codec => json { target => "TARGET_FIELD_NAME" }`,
-if `target` option is available in codec
+TIP: When ECS is enabled, set target in the codec (if the codec has a target option).
+Example: codec => json { target => "TARGET_FIELD_NAME" }
 
 
 [id="plugins-{type}s-{plugin}-truststore"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -251,26 +251,40 @@ Example output:
         },
         "@timestamp" => 2021-01-01T00:40:59.558Z
     },
-    "host" => {
-        "hostname" => "MacBook-Pro"
-    },
-    "url" => {
-        "full" => "http://localhost:8080/actuator/health"
-    },
-    "http" => {
-        "response" => {
-            "status" => {
-                "code" => 200
-            }
-        },
-         "request" => {
-            "method" => "get"
-        }
-    },
     "@version" => "1",
     "@timestamp" => 2021-01-01T00:40:59.559Z
 }
 -----
+
+**Sample error output: ECS enabled**
+[source,text]
+----
+{
+    "@timestamp" => 2021-07-09T09:53:48.721Z,
+    "@version" => "1",
+    "host" => {
+        "hostname" => "MacBook-Pro"
+    },
+    "http" => {
+        "request" => {
+            "method" => "get"
+        }
+    },
+    "event" => {
+        "duration" => 259019
+    },
+    "error" => {
+        "stack_trace" => nil,
+        "message" => "Connection refused (Connection refused)"
+    },
+    "url" => {
+        "full" => "http://localhost:8080/actuator/health"
+    },
+    "tags" => [
+        [0] "_http_request_failure"
+    ]
+}
+----
 
 [id="plugins-{type}s-{plugin}-follow_redirects"]
 ===== `follow_redirects` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -44,6 +44,7 @@ Here’s how ECS compatibility mode affects output.
 | [@metadata][host] | [host][hostname]  | Always | Hostname
 | [@metadata][code] | [http][response][status][code] | When server responds a valid status code | HTTP response code
 | [@metadata][response_headers] | [@metadata][input][http_poller][response][headers] | When server responds with headers | HTTP headers of the response
+| [@metadata][response_message] | [@metadata][input][http_poller][response][status][message] | When server responds with status line | message of status line of HTTP headers
 | [@metadata][runtime_seconds] / [http_request_failure][runtime_seconds] | [@metadata][input][http_poller][response][time][second] | Always | response time of calling endpoint
 | [@metadata][times_retried] | [@metadata][input][http_poller][request][retried] | When the poller calls server successfully | retry count from manticore
 | [@metadata][name] / [http_request_failure][name] | [@metadata][input][http_poller][request][name] | Always | The key of `urls` from poller config

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -421,8 +421,8 @@ Timeout (in seconds) to wait for data on the socket. Default is `10s`
 
 Define the target field for placing the received data. If this setting is omitted, the data will be stored at the root (top level) of the event.
 
-TIP: When ECS is enabled, set target in the codec (if the codec has a target option).
-Example: codec => json { target => "TARGET_FIELD_NAME" }
+TIP: When ECS is enabled, set `target` in the codec (if the codec has a `target` option).
+Example: `codec => json { target => "TARGET_FIELD_NAME" }`
 
 
 [id="plugins-{type}s-{plugin}-truststore"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,34 +25,6 @@ This Logstash input plugin allows you to call an HTTP API, decode the output of 
 send them on their merry way. The idea behind this plugins came from a need to read springboot
 metrics endpoint, instead of configuring jmx to monitor my java application memory/gc/ etc.
 
-[id="plugins-{type}s-{plugin}-ecs_metadata"]
-==== Event Metadata and the Elastic Common Schema (ECS)
-
-This input will add metadata about the HTTP connection itself to each event.
-
-When ECS compatibility is disabled, metadata was added to a variety of non-standard top-level fields, which has the potential to create confusion and schema conflicts downstream.
-
-With ECS Compatibility Mode, we can ensure a pipeline maintains access to this metadata throughout the event's lifecycle without polluting the top-level namespace.
-
-Here’s how ECS compatibility mode affects output.
-[cols="<l,<l,e,<e"]
-|=======================================================================
-| ECS disabled | ECS v1 | Availability | Description
-
-| [@metadata][request][url] | [url][full] | Always | The URL of the endpoint
-| [@metadata][request][method] | [http][request][method] | Always | HTTP request method
-| [@metadata][host] | [host][hostname]  | Always | Hostname
-| [@metadata][code] | [http][response][status][code] | When server responds a valid status code | HTTP response code
-| [@metadata][response_headers] | [@metadata][input][http_poller][response][headers] | When server responds with headers | HTTP headers of the response
-| [@metadata][response_message] | [@metadata][input][http_poller][response][status][message] | When server responds with status line | message of status line of HTTP headers
-| [@metadata][runtime_seconds] / [http_request_failure][runtime_seconds] | [@metadata][input][http_poller][response][time][second] | Always | response time of calling endpoint
-| [@metadata][times_retried] | [@metadata][input][http_poller][request][retried] | When the poller calls server successfully | retry count from manticore
-| [@metadata][name] / [http_request_failure][name] | [@metadata][input][http_poller][request][name] | Always | The key of `urls` from poller config
-| [@metadata][request] / [http_request_failure][request]| [@metadata][input][http_poller][request][original] | Always | The whole object of `urls` from poller config
-| [http_request_failure][error] | [error][message] | When server throws exception | Error message
-| [http_request_failure][backtrace] | [error][stack_trace] | When server throws exception | Stack trace of error
-|=======================================================================
-
 ==== Example
 Reads from a list of urls and decodes the body of the response with a codec.
 The config should look like this:
@@ -114,6 +86,36 @@ The above snippet will create two files `downloaded_cert.pem` and `downloaded_tr
  }
 ----------------------------------
 
+
+[id="plugins-{type}s-{plugin}-ecs_metadata"]
+==== Event Metadata and the Elastic Common Schema (ECS)
+
+This input will add metadata about the HTTP connection itself to each event.
+
+When ECS compatibility is disabled, metadata was added to a variety of non-standard top-level fields, which has the potential to create confusion and schema conflicts downstream.
+
+With ECS Compatibility Mode, we can ensure a pipeline maintains access to this metadata throughout the event's lifecycle without polluting the top-level namespace.
+
+Here’s how ECS compatibility mode affects output.
+[cols="<l,<l,e,<e"]
+|=======================================================================
+| ECS disabled | ECS v1 | Availability | Description
+
+| [@metadata][host] | [@metadata][input][http_poller][request][host][hostname] | Always | Hostname
+| [@metadata][code] | [@metadata][input][http_poller][response][status_code] | When server responds a valid status code | HTTP response code
+| [@metadata][response_headers] | [@metadata][input][http_poller][response][headers] | When server responds with headers | HTTP headers of the response
+| [@metadata][response_message] | [@metadata][input][http_poller][response][status_message] | When server responds with status line | message of status line of HTTP headers
+| [@metadata][runtime_seconds] | [@metadata][input][http_poller][response][elapsed_time_ns] | When server responds a valid status code | elapsed time of calling endpoint. ECS v1 shows in nanoseconds.
+| [http_request_failure][runtime_seconds] | [event][duration] | When server throws exception | elapsed time of calling endpoint. ECS v1 shows in nanoseconds.
+| [@metadata][times_retried] | [@metadata][input][http_poller][request][retry_count] | When the poller calls server successfully | retry count from http client library
+| [@metadata][name] / [http_request_failure][name] | [@metadata][input][http_poller][request][name] | Always | The key of `urls` from poller config
+| [@metadata][request] / [http_request_failure][request]| [@metadata][input][http_poller][request][original] | Always | The whole object of `urls` from poller config
+| [http_request_failure][error] | [error][message] | When server throws exception | Error message
+| [http_request_failure][backtrace] | [error][stack_trace] | When server throws exception | Stack trace of error
+| -- | [url][full] | When server throws exception | The URL of the endpoint
+| -- | [http][request][method] | When server throws exception | HTTP request method
+| -- | [host][hostname] | When server throws exception | Hostname
+|=======================================================================
 
 [id="plugins-{type}s-{plugin}-options"]
 ==== Http_poller Input Configuration Options

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -25,6 +25,33 @@ This Logstash input plugin allows you to call an HTTP API, decode the output of 
 send them on their merry way. The idea behind this plugins came from a need to read springboot
 metrics endpoint, instead of configuring jmx to monitor my java application memory/gc/ etc.
 
+[id="plugins-{type}s-{plugin}-ecs_metadata"]
+==== Event Metadata and the Elastic Common Schema (ECS)
+
+This input will add metadata about the HTTP connection itself to each event.
+
+When ECS compatibility is disabled, metadata was added to a variety of non-standard top-level fields, which has the potential to create confusion and schema conflicts downstream.
+
+With ECS Compatibility Mode, we can ensure a pipeline maintains access to this metadata throughout the event's lifecycle without polluting the top-level namespace.
+
+Here’s how ECS compatibility mode affects output.
+[cols="<l,<l,e,<e"]
+|=======================================================================
+| ECS disabled | ECS v1 | Availability | Description
+
+| [@metadata][request][url] | [url][full] | Always | The URL of the endpoint
+| [@metadata][request][method] | [http][request][method] | Always | HTTP request method
+| [@metadata][host] | [host][hostname]  | Always | Hostname
+| [@metadata][code] | [http][response][status][code] | When server responds a valid status code | HTTP response code
+| [@metadata][response_headers] | [@metadata][input][http_poller][response][headers] | When server responds with headers | HTTP headers of the response
+| [@metadata][runtime_seconds] / [http_request_failure][runtime_seconds] | [@metadata][input][http_poller][response][time][second] | Always | response time of calling endpoint
+| [@metadata][times_retried] | [@metadata][input][http_poller][request][retried] | When the poller calls server successfully | retry count from manticore
+| [@metadata][name] / [http_request_failure][name] | [@metadata][input][http_poller][request][name] | Always | The key of `urls` from poller config
+| [@metadata][request] / [http_request_failure][request]| [@metadata][input][http_poller][request][original] | Always | The whole object of `urls` from poller config
+| [http_request_failure][error] | [error][message] | When server throws exception | Error message
+| [http_request_failure][backtrace] | [error][stack_trace] | When server throws exception | Stack trace of error
+|=======================================================================
+
 ==== Example
 Reads from a list of urls and decodes the body of the response with a codec.
 The config should look like this:
@@ -101,6 +128,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-client_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|No
@@ -179,6 +207,67 @@ Timeout (in seconds) to wait for a connection to be established. Default is `10s
 
 Enable cookie support. With this enabled the client will persist cookies
 across requests as a normal web browser would. Enabled by default
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: unstructured data added at root level
+** `v1`: uses `error`, `url` and `http` fields that are compatible with Elastic Common Schema
+
+Controls this plugin's compatibility with the
+{ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs_metadata>> for detailed information.
+
+Example output:
+
+**Sample output: ECS disabled**
+[source,text]
+-----
+{
+    "http_poller_data" => {
+        "@version" => "1",
+        "@timestamp" => 2021-01-01T00:43:22.388Z,
+        "status" => "UP"
+    },
+    "@version" => "1",
+    "@timestamp" => 2021-01-01T00:43:22.389Z,
+}
+-----
+
+**Sample output: ECS enabled**
+[source,text]
+-----
+{
+    "http_poller_data" => {
+        "status" => "UP",
+        "@version" => "1",
+        "event" => {
+            "original" => "{\"status\":\"UP\"}"
+        },
+        "@timestamp" => 2021-01-01T00:40:59.558Z
+    },
+    "host" => {
+        "hostname" => "MacBook-Pro"
+    },
+    "url" => {
+        "full" => "http://localhost:8080/actuator/health"
+    },
+    "http" => {
+        "response" => {
+            "status" => {
+                "code" => 200
+            }
+        },
+         "request" => {
+            "method" => "get"
+        }
+    },
+    "@version" => "1",
+    "@timestamp" => 2021-01-01T00:40:59.559Z
+}
+-----
 
 [id="plugins-{type}s-{plugin}-follow_redirects"]
 ===== `follow_redirects` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -421,7 +421,8 @@ Timeout (in seconds) to wait for data on the socket. Default is `10s`
 
 Define the target field for placing the received data. If this setting is omitted, the data will be stored at the root (top level) of the event.
 
-When ECS is enabled and user wants to define `target` field, it is preferable to set `target` in codec if codec has `target` option.
+When ECS is enabled, it is preferable to set `target` in codec, `codec => json { target => "TARGET_FIELD_NAME" }`,
+if `target` option is available in codec
 
 
 [id="plugins-{type}s-{plugin}-truststore"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -421,6 +421,9 @@ Timeout (in seconds) to wait for data on the socket. Default is `10s`
 
 Define the target field for placing the received data. If this setting is omitted, the data will be stored at the root (top level) of the event.
 
+When ECS is enabled and user wants to define `target` field, it is preferable to set `target` in codec if codec has `target` option.
+
+
 [id="plugins-{type}s-{plugin}-truststore"]
 ===== `truststore` 
 

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -54,6 +54,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     @host_field = ecs_select[disabled: "[#{metadata_target}][host]", v1: "[host][hostname]"]
     @response_code_field = ecs_select[disabled: "[#{metadata_target}][code]", v1: "[http][response][status][code]"]
     @response_headers_field = ecs_select[disabled: "[#{metadata_target}][response_headers]", v1: "[#{metadata_target}][input][http_poller][response][headers]"]
+    @response_message_field = ecs_select[disabled: "[#{metadata_target}][response_message]", v1: "[#{metadata_target}][input][http_poller][response][status][message]"]
     @response_time_field = ecs_select[disabled: "[#{metadata_target}][runtime_seconds]", v1: "[#{metadata_target}][input][http_poller][response][time][second]"]
     @request_retried_field = ecs_select[disabled: "[#{metadata_target}][times_retried]", v1: "[#{metadata_target}][input][http_poller][request][retried]"]
     @request_name_field = ecs_select[disabled: "[#{metadata_target}][name]", v1: "[#{metadata_target}][input][http_poller][request][name]"]
@@ -272,6 +273,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     if response
       event.set(@response_code_field, response.code)
       event.set(@response_headers_field, response.headers)
+      event.set(@response_message_field, response.message)
       event.set(@request_retried_field, response.times_retried)
     end
   end

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -9,17 +9,14 @@ require "logstash/plugin_mixins/ecs_compatibility_support"
 require 'logstash/plugin_mixins/ecs_compatibility_support/target_check'
 require 'logstash/plugin_mixins/validator_support/field_reference_validation_adapter'
 require 'logstash/plugin_mixins/event_support/event_factory_adapter'
-require 'logstash/plugin_mixins/event_support/from_json_helper'
 
 class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   include LogStash::PluginMixins::HttpClient
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
   include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
+  include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
 
   extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
-
-  include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
-  include LogStash::PluginMixins::EventSupport::FromJsonHelper
 
   config_name "http_poller"
 

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -197,7 +197,6 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   private
   # time diff in float to nanoseconds
   def to_nanoseconds(time_diff)
-    return nil if time_diff.nil?
     (time_diff * 1000000).to_i
   end
 
@@ -265,7 +264,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   end
 
   private
-  def apply_metadata(event, name, request, response=nil, execution_time=nil)
+  def apply_metadata(event, name, request, response, execution_time)
     return unless @metadata_target
 
     event.set(@request_host_field, @host)

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -53,21 +53,16 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     @method_field = ecs_select[disabled: "[#{metadata_target}][request][method]", v1: "[http][request][method]"]
     @host_field = ecs_select[disabled: "[#{metadata_target}][host]", v1: "[host][hostname]"]
     @response_code_field = ecs_select[disabled: "[#{metadata_target}][code]", v1: "[http][response][status][code]"]
-    @response_headers_field = ecs_select_metadata_target(disabled: "[#{metadata_target}][response_headers]", v1: "[@metadata][input][http_poller][response][headers]")
-    @response_time_field = ecs_select_metadata_target(disabled: "[#{metadata_target}][runtime_seconds]", v1: "[@metadata][input][http_poller][response][time][second]")
-    @request_retried_field = ecs_select_metadata_target(disabled: "[#{metadata_target}][times_retried]", v1: "[@metadata][input][http_poller][request][retried]")
-    @request_name_field = ecs_select_metadata_target(disabled: "[#{metadata_target}][name]", v1: "[@metadata][input][http_poller][request][name]")
-    @request_manticore_field = ecs_select_metadata_target(disabled: "[#{metadata_target}][request]", v1: "[@metadata][input][http_poller][request][original]")
+    @response_headers_field = ecs_select[disabled: "[#{metadata_target}][response_headers]", v1: "[#{metadata_target}][input][http_poller][response][headers]"]
+    @response_time_field = ecs_select[disabled: "[#{metadata_target}][runtime_seconds]", v1: "[#{metadata_target}][input][http_poller][response][time][second]"]
+    @request_retried_field = ecs_select[disabled: "[#{metadata_target}][times_retried]", v1: "[#{metadata_target}][input][http_poller][request][retried]"]
+    @request_name_field = ecs_select[disabled: "[#{metadata_target}][name]", v1: "[#{metadata_target}][input][http_poller][request][name]"]
+    @request_manticore_field = ecs_select[disabled: "[#{metadata_target}][request]", v1: "[#{metadata_target}][input][http_poller][request][original]"]
     @error_msg_field = ecs_select[disabled: "[http_request_failure][error]", v1: "[error][message]"]
     @stack_trace_field = ecs_select[disabled: "[http_request_failure][backtrace]", v1: "[error][stack_trace]"]
     @fail_response_time_field = ecs_select[disabled: "[http_request_failure][runtime_seconds]", v1: "[@metadata][input][http_poller][response][time][second]"]
 
     setup_requests!
-  end
-
-  def ecs_select_metadata_target(hash)
-    return hash[:v1] if ecs_compatibility != :disabled && @metadata_target == '@metadata'
-    hash[:disabled]
   end
 
   def stop

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', "~> 0.0.22"
   s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-codec-json'
   s.add_development_dependency 'logstash-codec-line'

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '5.0.2'
+  s.version         = '5.1.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-mixin-http_client', "~> 7"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
   s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
 
   s.add_development_dependency 'logstash-codec-json'
   s.add_development_dependency 'logstash-codec-line'

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -287,7 +287,7 @@ describe LogStash::Inputs::HTTP_Poller do
   end
 
   describe "events", :ecs_compatibility_support, :aggregate_failures do
-    ecs_compatibility_matrix(:disabled, :v1) do |ecs_select|
+    ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
       before do
         allow_any_instance_of(described_class).to receive(:ecs_compatibility).and_return(ecs_compatibility)
       end
@@ -495,18 +495,18 @@ describe LogStash::Inputs::HTTP_Poller do
           let(:metadata_target) { "@metadata" }
 
           it "should store the metadata info in @metadata" do
-            if ecs_compatibility == :v1
-              expect(event.get("[@metadata][input][http_poller][response][headers]")).to be_a(Hash)
-              expect(event.get("[@metadata][input][http_poller][response][time][second]")).to be_a(Float)
-              expect(event.get("[@metadata][input][http_poller][request][retried]")).to eq(0)
-              expect(event.get("[@metadata][input][http_poller][request][name]")).to eq(default_name)
-              expect(event.get("[@metadata][input][http_poller][request][original]")).to be_a(Hash)
-            else
+            if ecs_compatibility == :disabled
               expect(event.get("[@metadata][response_headers]")).to be_a(Hash)
               expect(event.get("[@metadata][runtime_seconds]")).to be_a(Float)
               expect(event.get("[@metadata][times_retried]")).to eq(0)
               expect(event.get("[@metadata][name]")).to eq(default_name)
               expect(event.get("[@metadata][request]")).to be_a(Hash)
+            else
+              expect(event.get("[@metadata][input][http_poller][response][headers]")).to be_a(Hash)
+              expect(event.get("[@metadata][input][http_poller][response][time][second]")).to be_a(Float)
+              expect(event.get("[@metadata][input][http_poller][request][retried]")).to eq(0)
+              expect(event.get("[@metadata][input][http_poller][request][name]")).to eq(default_name)
+              expect(event.get("[@metadata][input][http_poller][request][original]")).to be_a(Hash)
             end
           end
         end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -257,7 +257,7 @@ describe LogStash::Inputs::HTTP_Poller do
         instance.stop
         runner.kill
         runner.join
-        expect(queue.size).to eq(3)
+        expect(queue.size).to be_between(2, 3)
       end
     end
 


### PR DESCRIPTION
This PR restructures `@metadata` and maps them to ECS fields

For the valid HTTP response, restructure metadata
| Legacy  | ECS |
| ------------- | ------------- |
| [@metadata][host] |  [@metadata][input][http_poller][request][host][hostname]  |
| [@metadata][code] |  [@metadata][input][http_poller][response][status_code] |
| [@metadata][response_message] | [@metadata][input][http_poller][response][status_message] |
| [@metadata][response_headers] | [@metadata][input][http_poller][response][headers] |
| [@metadata][runtime_seconds] | -- |
| -- | [@metadata][input][http_poller][response][elapsed_time_ns] |
| [@metadata][times_retried] | [@metadata][input][http_poller][request][retry_count] |
| [@metadata][name] | [@metadata][input][http_poller][request][name] |
| [@metadata][request] | [@metadata][input][http_poller][request][original] |


For the failure case, metadata map to `error.*`, `url.*`, `host.*`, `http.*`
| Legacy  | ECS |
| ------------- | ------------- |
| [http_request_failure][error] | [error][message] |
| [http_request_failure][backtrace] | [error][stack_trace] |
| [http_request_failure][runtime_seconds] | -- |
| -- | [event][duration] |
| [http_request_failure][name] | [@metadata][input][http_poller][request][name] |
| [http_request_failure][request] | [@metadata][input][http_poller][request][original] |
| -- | [url][full] |
| -- | [http][request][method] |
| -- | [host][hostname] |

