### PR TITLE
Fix: make sure plugin is closing the http client

### DIFF
--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -1,0 +1,6 @@
+#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
+# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
+# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
+# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
+# - `-v -W1` print JRuby version but do not go verbose
+JRUBY_OPTS=-J-Xms128m -J-Xmx1g -J-XX:MaxMetaspaceSize=256m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -3,4 +3,4 @@
 # - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -J-Djava.security.egd=file:/dev/./urandom -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -1,8 +1,0 @@
-#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
-# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
-# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
-# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
-# - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.mode=OFF -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
-
-# default on CI (wout -Xmx) -XX:InitialHeapSize=130380544 -XX:MaxHeapSize=2086088704

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -3,4 +3,4 @@
 # - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -J-Djava.security.egd=file:/dev/./urandom -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.mode=OFF -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -3,4 +3,4 @@
 # - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms128m -J-Xmx1g -J-XX:MaxMetaspaceSize=256m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -4,3 +4,5 @@
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
 JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.mode=OFF -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+
+# default on CI (wout -Xmx) -XX:InitialHeapSize=130380544 -XX:MaxHeapSize=2086088704

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ import:
 
 env:
   jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
-    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=info
+    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=debug
     - ELASTIC_STACK_VERSION=8.2.0 RUFUS_SCHEDULER_VERSION=3.0.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ import:
   - logstash-plugins/.ci:travis/travis.yml@1.x
 
 env:
-  global:
-    - LOG_LEVEL=info
   jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
-    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=debug
+    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=info
     - ELASTIC_STACK_VERSION=8.2.0 RUFUS_SCHEDULER_VERSION=3.0.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ import:
 env:
   jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
     - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=info
-    - ELASTIC_STACK_VERSION=6.x RUFUS_SCHEDULER_VERSION=3.0.9
+    - ELASTIC_STACK_VERSION=8.2.0 RUFUS_SCHEDULER_VERSION=3.0.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ import:
   - logstash-plugins/.ci:travis/travis.yml@1.x
 
 env:
+  global:
+    - LOG_LEVEL=info
   jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
     - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=debug
     - ELASTIC_STACK_VERSION=8.2.0 RUFUS_SCHEDULER_VERSION=3.0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.1
+  - Fix: make sure plugin is closing the http client [#130](https://github.com/logstash-plugins/logstash-input-http_poller/pull/130)
+
 ## 5.3.0
   - Feat: added ssl_supported_protocols option [#133](https://github.com/logstash-plugins/logstash-input-http_poller/pull/133)
 

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -49,8 +49,6 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   def register
     @host = Socket.gethostname.force_encoding(Encoding::UTF_8)
 
-    @logger.info("Registering http_poller Input", :type => @type, :schedule => @schedule, :timeout => @timeout)
-
     setup_ecs_field!
     setup_requests!
   end
@@ -66,16 +64,16 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   end
 
   def shutdown_scheduler_and_close_client(opt = nil)
-    @logger.debug("Closing http client", client: client)
+    @logger.debug("closing http client", client: client)
     begin
       client.close # since Manticore 0.9.0 this shuts-down/closes all resources
     rescue => e
       details = { exception: e.class, message: e.message }
-      details[:backtrace] = e.backtrace if logger.info?
-      logger.warn "failed while closing http client", details
+      details[:backtrace] = e.backtrace if @logger.debug?
+      @logger.info "failed closing http client", details
     end
     if @scheduler
-      @logger.debug("Shutting down scheduler", scheduler: @scheduler)
+      @logger.debug("shutting down scheduler", scheduler: @scheduler)
       @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
     end
   end

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -218,24 +218,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     rescue => e
       logger.warn "failed while closing http client", exception: e.class, message: e.message
     end
-
-    begin
-      client.clear_pending
-      client.instance_variable_get(:@async_requests).close
-    rescue => e
-      logger.warn "failed while clearing async queue", exception: e.class, message: e.message
-    end
-
-    ObjectSpace.undefine_finalizer client # avoid leaking - waiting for runtime shutdown!
-
-    finalizers = client.instance_variable_get :@finalizers
-    finalizers.each do |obj, args|
-      begin
-        obj.send(*args) if obj.weakref_alive?
-      rescue => e
-        logger.debug "failed to #{args.first} http client resource: #{obj}", exception: e.class, message: e.message
-      end
-    end
+    #client.clear_pending
   end
 
   private

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -57,10 +57,13 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   # @overload
   def stop
-    if @scheduler
-      @scheduler.shutdown # on newer Rufus (3.8) this joins on the scheduler thread
-    end
     # TODO implement client.close as we as releasing it's pooled resources!
+    @scheduler.shutdown(:wait) if @scheduler
+  end
+
+  # @overload
+  def close
+    @scheduler.shutdown if @scheduler
   end
 
   private

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -70,7 +70,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     rescue => e
       details = { exception: e.class, message: e.message }
       details[:backtrace] = e.backtrace if @logger.debug?
-      @logger.info "failed closing http client", details
+      @logger.warn "failed closing http client", details
     end
     if @scheduler
       @logger.debug("shutting down scheduler", scheduler: @scheduler)

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -58,12 +58,12 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   # @overload
   def stop
     # TODO implement client.close as we as releasing it's pooled resources!
-    shutdown_scheduler_and_release_client
+    shutdown_scheduler_and_release_client(:wait)
   end
 
   # @overload
   def close
-    shutdown_scheduler_and_release_client(:kill)
+    shutdown_scheduler_and_release_client
   end
 
   def shutdown_scheduler_and_release_client(opt = nil)

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -59,11 +59,13 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   def stop
     # TODO implement client.close as we as releasing it's pooled resources!
     @scheduler.shutdown(:wait) if @scheduler
+    close_client!
   end
 
   # @overload
   def close
     @scheduler.shutdown if @scheduler
+    close_client!
   end
 
   private
@@ -197,6 +199,25 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     client.async.send(method, *request_opts).
       on_success {|response| handle_success(queue, name, request, response, Time.now - started) }.
       on_failure {|exception| handle_failure(queue, name, request, exception, Time.now - started) }
+  end
+
+  def close_client!
+    ObjectSpace.undefine_finalizer client # avoid leaking - waiting for runtime shutdown!
+
+    finalizers = client.instance_variable_get :@finalizers
+    finalizers.each do |obj, args|
+      begin
+        obj.send(*args) if obj.weakref_alive?
+      rescue => e
+        logger.debug "failed to #{args.first} http client resource: #{obj}", exception: e.class, message: e.message
+      end
+    end
+
+    begin
+      client.close
+    rescue => e
+      logger.warn "failed while closing http client", exception: e.class, message: e.message
+    end
   end
 
   private

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -195,10 +195,13 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   def run_once(queue)
     @requests.each do |name, request|
+      # prevent executing a scheduler kick after the plugin has been stop-ed
+      # this could easily happen as the scheduler shutdown is not immediate
+      return if stop?
       request_async(queue, name, request)
     end
 
-    client.execute!
+    client.execute! unless stop?
   end
 
   private

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -68,10 +68,13 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   def shutdown_scheduler_and_release_client(opt = nil)
     if @scheduler
-      @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
       thread = @scheduler.thread
-      thread.wakeup if thread && thread.status == 'sleep'
+      @logger.debug("Shutting down scheduler", scheduler: @scheduler, thread: thread)
+      thread.wakeup if thread && thread.status
+      @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
+      thread.wakeup if thread && thread.status
     end
+    @logger.debug("Closing http client", client: client)
     close_client!
   end
   private :shutdown_scheduler_and_release_client

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -203,7 +203,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   private
   def request_async(queue, name, request)
-    @logger.debug? && @logger.debug("Fetching URL", :name => name, :url => request)
+    @logger.debug? && @logger.debug("async queueing fetching url", name: name, url: request)
     started = Time.now
 
     method, *request_opts = request
@@ -220,6 +220,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   private
   def handle_success(queue, name, request, response, execution_time)
+    @logger.debug? && @logger.debug("success fetching url", name: name, url: request)
     body = response.body
     # If there is a usable response. HEAD requests are `nil` and empty get
     # responses come up as "" which will cause the codec to not yield anything
@@ -258,6 +259,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   private
   # Beware, on old versions of manticore some uncommon failures are not handled
   def handle_failure(queue, name, request, exception, execution_time)
+    @logger.debug? && @logger.debug("failed fetching url", name: name, url: request)
     event = event_factory.new_event
     event.tag("_http_request_failure")
     apply_metadata(event, name, request, nil, execution_time)

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -66,15 +66,17 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   end
 
   def shutdown_scheduler_and_close_client(opt = nil)
-    if @scheduler
-      @logger.debug("Shutting down scheduler", scheduler: @scheduler)
-      @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
-    end
     @logger.debug("Closing http client", client: client)
     begin
       client.close # since Manticore 0.9.0 this shuts-down/closes all resources
     rescue => e
-      logger.warn "failed while closing http client", exception: e.class, message: e.message
+      details = { exception: e.class, message: e.message }
+      details[:backtrace] = e.backtrace if logger.info?
+      logger.warn "failed while closing http client", details
+    end
+    if @scheduler
+      @logger.debug("Shutting down scheduler", scheduler: @scheduler)
+      @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
     end
   end
   private :shutdown_scheduler_and_close_client

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version     = '5.3.0'
+  s.version     = '5.3.1'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -410,10 +410,7 @@ describe LogStash::Inputs::HTTP_Poller do
         before do
           plugin.register
           u = url.is_a?(Hash) ? url["url"] : url # handle both complex specs and simple string URLs
-          plugin.client.stub(u,
-                               :body => response_body,
-                               :code => code
-          )
+          plugin.client.stub(u, :body => response_body, :code => code)
           allow(plugin).to receive(:decorate)
           plugin.send(:run_once, queue)
         end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -555,10 +555,10 @@ describe LogStash::Inputs::HTTP_Poller do
   end
 
   describe "stopping" do
-    # let(:config) { default_opts }
-    # it_behaves_like "an interruptible input plugin" do
-    #   let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
-    # end
+    let(:config) { default_opts }
+    it_behaves_like "an interruptible input plugin" do
+      let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
+    end
 
     let(:queue) { SizedQueue.new(20) }
     before(:each) do
@@ -566,7 +566,7 @@ describe LogStash::Inputs::HTTP_Poller do
       #java.lang.System.gc
     end
 
-    it "returns from run" do
+    xit "returns from run" do
       Thread.start(queue) { |queue| loop { queue.pop } }
       plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
       # the run method is a long lived one, so it should still be running after "a bit"

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -572,12 +572,13 @@ describe LogStash::Inputs::HTTP_Poller do
       subject.do_stop
       sleep 2.5
 
-      if plugin_thread.alive?
+      #if plugin_thread.alive?
         require 'jruby'
         runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.raw_thread_dump
+        puts runtime.thread_dump
         puts '-' * 150
-      end
+        puts runtime.raw_thread_dump
+      #end
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
@@ -585,7 +586,7 @@ describe LogStash::Inputs::HTTP_Poller do
         try(10) { expect(plugin_thread).to_not be_alive }
       ensure
         # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        # puts runtime.thread_dump
+        # puts runtime.raw_thread_dump
       end
     end
   end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -7,6 +7,15 @@ require "timecop"
 require 'rspec/matchers/built_in/raise_error.rb'
 require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
+begin
+  # TODO: CI work-around - will most likely be moved to the scheduler mixin
+  require 'et-orbi.rb' # a dependency of rufus-scheduler since 3.4
+  ::EtOrbi::EoTime.now # might take a long time to initialize - loading timezones
+  # from tz-info and thus gets un-predictable on CI, since the scheduler worker
+  # might be stuck loading dependencies while we
+rescue LoadError
+end
+
 describe LogStash::Inputs::HTTP_Poller do
   let(:metadata_target) { "_http_poller_metadata" }
   let(:queue) { Queue.new }

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,7 +570,16 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      try(10) { sleep(1.0); expect(plugin_thread).to_not be_alive }
+
+      require 'jruby'
+      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
+      puts runtime.thread_dump
+      puts '-' * 150
+
+      try(10) { expect(plugin_thread).to_not be_alive }
+      if plugin_thread.alive?
+        puts runtime.thread_dump
+      end
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -201,8 +201,8 @@ describe LogStash::Inputs::HTTP_Poller do
       end
 
       it "should run at the schedule" do
-        run_plugin_and_yield_queue(plugin, sleep: 3) do |queue|
-          try(5) { expect(queue.size).to be >= 2 }
+        run_plugin_and_yield_queue(plugin, sleep: 3.1) do |queue|
+          try(10) { expect(queue.size).to be >= 2 }
         end
       end
     end
@@ -227,8 +227,8 @@ describe LogStash::Inputs::HTTP_Poller do
       end
 
       it "should run at the schedule" do
-        run_plugin_and_yield_queue(plugin, sleep: 4.05) do |queue|
-          try(5) { expect(queue.size).to eq(1) }
+        run_plugin_and_yield_queue(plugin, sleep: 4.1) do |queue|
+          try(10) { expect(queue.size).to eq(1) }
         end
       end
     end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,19 +570,22 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
+      sleep 1.5
 
-      require 'jruby'
-      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-      puts runtime.thread_dump
-      puts '-' * 150
+      if plugin_thread.alive?
+        require 'jruby'
+        runtime = org.jruby.management.Runtime.new(JRuby.runtime)
+        puts runtime.thread_dump
+        puts '-' * 150
+      end
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
       begin
         try(10) { expect(plugin_thread).to_not be_alive }
       ensure
-        puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        puts runtime.thread_dump
+        # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+        # puts runtime.thread_dump
       end
     end
   end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -227,7 +227,7 @@ describe LogStash::Inputs::HTTP_Poller do
       end
 
       it "should run at the schedule" do
-        run_plugin_and_yield_queue(plugin, sleep: 2) do |queue|
+        run_plugin_and_yield_queue(plugin, sleep: 4.05) do |queue|
           try(5) { expect(queue.size).to eq(1) }
         end
       end
@@ -247,7 +247,7 @@ describe LogStash::Inputs::HTTP_Poller do
           #T       0123456
           #events  x x x x
           #expects 3 events at T=5
-          try(5) { expect(queue.size).to be_between(2, 3) }
+          try(10) { expect(queue.size).to be_between(2, 3) }
         end
       end
     end
@@ -255,15 +255,15 @@ describe LogStash::Inputs::HTTP_Poller do
     context "given 'in' expression" do
       let(:opts) {
         {
-          "schedule" => { "in" => "2s"},
+          "schedule" => { "in" => "1s"},
           "urls" => default_urls,
           "codec" => "json",
           "metadata_target" => metadata_target
         }
       }
       it "should run at the schedule" do
-        run_plugin_and_yield_queue(plugin, sleep: 2.5) do |queue|
-          try(5) { expect(queue.size).to eq(1) }
+        run_plugin_and_yield_queue(plugin, sleep: 2.05) do |queue|
+          try(10) { expect(queue.size).to eq(1) }
         end
       end
     end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -578,10 +578,12 @@ describe LogStash::Inputs::HTTP_Poller do
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
-      try(10) { expect(plugin_thread).to_not be_alive }
-
-      puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-      puts runtime.thread_dump
+      begin
+        try(10) { expect(plugin_thread).to_not be_alive }
+      ensure
+        puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+        puts runtime.thread_dump
+      end
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -10,9 +10,9 @@ require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 begin
   # TODO: CI work-around - will most likely be moved to the scheduler mixin
   require 'et-orbi.rb' # a dependency of rufus-scheduler since 3.4
-  ::EtOrbi::EoTime.now # might take a long time to initialize - loading timezones
-  # from tz-info and thus gets un-predictable on CI, since the scheduler worker
-  # might be stuck loading dependencies while we
+  ::EtOrbi::EoTime.now # might take a long time to initialize - loading time zone
+  # data (from tz-info) and thus gets un-predictable on CI, since the scheduler worker
+  # thread might be stuck starting while we attempt to shutdown in a given time frame
 rescue LoadError
 end
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -553,7 +553,7 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 10 } # CI: wait till scheduler shuts down
+      let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -576,10 +576,12 @@ describe LogStash::Inputs::HTTP_Poller do
       puts runtime.thread_dump
       puts '-' * 150
 
+      puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+
       try(10) { expect(plugin_thread).to_not be_alive }
-      if plugin_thread.alive?
-        puts runtime.thread_dump
-      end
+
+      puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+      puts runtime.thread_dump
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -554,7 +554,7 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
+      let(:allowed_lag) { 60 } # CI: wait till scheduler shuts down
     end
 
     let(:queue) { SizedQueue.new(20) }
@@ -563,7 +563,7 @@ describe LogStash::Inputs::HTTP_Poller do
       #java.lang.System.gc
     end
 
-    xit "returns from run" do
+    it "returns from run" do
       Thread.start(queue) { |queue| loop { queue.pop } }
       plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
       # the run method is a long lived one, so it should still be running after "a bit"
@@ -571,18 +571,16 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      sleep 1.5
+      sleep 1.0
 
-      #if plugin_thread.alive?
-        require 'jruby'
-        runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.thread_dump
-      #end
+      require 'jruby'
+      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
+      puts runtime.thread_dump #if plugin_thread.alive?
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
       begin
-        try(10) { sleep 1.5; expect(plugin_thread).to_not be_alive }
+        try(10) { sleep 0.5; expect(plugin_thread).to_not be_alive }
       rescue Exception => e
         puts '-' * 150
         puts runtime.raw_thread_dump

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -563,41 +563,7 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 60 } # CI: wait till scheduler shuts down
-    end
-
-    let(:queue) { SizedQueue.new(20) }
-    before(:each) do
-      subject.register
-      #java.lang.System.gc
-    end
-
-    it "returns from run" do
-      Thread.start(queue) { |queue| loop { queue.pop } }
-      plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
-      # the run method is a long lived one, so it should still be running after "a bit"
-      sleep 0.5
-      try(5) { expect(plugin_thread).to be_alive }
-      # now let's actually stop the plugin
-      subject.do_stop
-      sleep 1.0
-
-      require 'jruby'
-      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-      puts runtime.thread_dump #if plugin_thread.alive?
-
-      puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-
-      begin
-        try(10) { sleep 0.5; expect(plugin_thread).to_not be_alive }
-      rescue Exception => e
-        puts '-' * 150
-        puts runtime.raw_thread_dump
-        raise e
-      ensure
-        # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        # puts runtime.raw_thread_dump
-      end
+      let(:allowed_lag) { 10 } # CI: wait till scheduler shuts down
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,12 +570,12 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      sleep 1.5
+      sleep 2.5
 
       if plugin_thread.alive?
         require 'jruby'
         runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.thread_dump
+        puts runtime.raw_thread_dump
         puts '-' * 150
       end
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -559,7 +559,7 @@ describe LogStash::Inputs::HTTP_Poller do
     let(:queue) { SizedQueue.new(20) }
     before(:each) do
       subject.register
-      java.lang.System.gc
+      #java.lang.System.gc
     end
 
     it "returns from run" do
@@ -570,20 +570,22 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      sleep 2.5
+      sleep 1.5
 
       #if plugin_thread.alive?
         require 'jruby'
         runtime = org.jruby.management.Runtime.new(JRuby.runtime)
         puts runtime.thread_dump
-        puts '-' * 150
-        puts runtime.raw_thread_dump
       #end
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
       begin
-        try(10) { expect(plugin_thread).to_not be_alive }
+        try(10) { sleep 1.5; expect(plugin_thread).to_not be_alive }
+      rescue Exception => e
+        puts '-' * 150
+        puts runtime.raw_thread_dump
+        raise e
       ensure
         # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
         # puts runtime.raw_thread_dump

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -418,6 +418,10 @@ describe LogStash::Inputs::HTTP_Poller do
           plugin.send(:run_once, queue)
         end
 
+        after do
+          plugin.close
+        end
+
         it "should have a matching message" do
           expect(event.to_hash).to include(payload)
         end


### PR DESCRIPTION
On plugin close we should make sure to `client.close` the HTTP client.
This is esp. important since this plugin uses `client.async` to fetch requests asynchronously.
The client starts a thread pool for async requests.

NOTE: the `client.close` operation only closed the internal HTTP client, but since Manticore 0.9.0 it will [also close](https://github.com/cheald/manticore/pull/108) the connection pool and shuts down the (async) executor thread pool.

---
~~CI :red_circle: happens after the unpinning but is likely related to https://github.com/elastic/logstash/issues/13572~~