### PR TITLE
Deps: allow any scheduler version with plugin

### DIFF
--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -1,0 +1,6 @@
+#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
+# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
+# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
+# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
+# - `-v -W1` print JRuby version but do not go verbose
+JRUBY_OPTS=-J-Xms128m -J-Xmx1g -J-XX:MaxMetaspaceSize=256m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -3,4 +3,4 @@
 # - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -J-Djava.security.egd=file:/dev/./urandom -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -1,6 +1,0 @@
-#LS_JAVA_OPTS="-Xms256m -Xmx256m -XX:MaxMetaspaceSize=256m"
-# Common LS options (can be overridden from ENV e.g. in .travis.yml) :
-# - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
-# - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
-# - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.mode=OFF -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -3,4 +3,4 @@
 # - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -J-Djava.security.egd=file:/dev/./urandom -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.mode=OFF -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.ci/docker.env
+++ b/.ci/docker.env
@@ -3,4 +3,4 @@
 # - `-Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0` LS base-line
 # - `-XX:+UseParallelGC` do not use G1 (default) on Java 11
 # - `-v -W1` print JRuby version but do not go verbose
-JRUBY_OPTS=-J-Xms128m -J-Xmx1g -J-XX:MaxMetaspaceSize=256m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1
+JRUBY_OPTS=-J-Xms120m -J-Xmx800m -J-XX:MaxMetaspaceSize=200m -Xregexp.interruptible=true -Xcompile.invokedynamic=true -Xjit.threshold=0 -J-XX:+UseParallelGC -J-XX:+PrintCommandLineFlags -v -W1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 import:
-- logstash-plugins/.ci:travis/travis.yml@1.x
+  - logstash-plugins/.ci:travis/travis.yml@1.x
+
+env:
+  jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
+    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9
+    - ELASTIC_STACK_VERSION=6.x RUFUS_SCHEDULER_VERSION=3.0.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ import:
 
 env:
   jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
-    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9
+    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=info
     - ELASTIC_STACK_VERSION=6.x RUFUS_SCHEDULER_VERSION=3.0.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ import:
 
 env:
   jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
-    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=info
+    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=debug
     - ELASTIC_STACK_VERSION=6.x RUFUS_SCHEDULER_VERSION=3.0.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ import:
 
 env:
   jobs: # test with old scheduler version (3.0 was locked in LS 7.x)
-    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=debug
+    - ELASTIC_STACK_VERSION=7.x RUFUS_SCHEDULER_VERSION=3.0.9 LOG_LEVEL=info
     - ELASTIC_STACK_VERSION=6.x RUFUS_SCHEDULER_VERSION=3.0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 ## 5.2.0
   - Feat: support ssl_verification_mode option [#131](https://github.com/logstash-plugins/logstash-input-http_poller/pull/131)
 
-
 ## 5.1.0
   - Add ECS support [#129](https://github.com/logstash-plugins/logstash-input-http_poller/pull/129)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.1
+  - Deps: unpin rufus-scheduler dependency [#130](https://github.com/logstash-plugins/logstash-input-http_poller/pull/130)
+
 ## 5.1.0
   - Add ECS support [#129](https://github.com/logstash-plugins/logstash-input-http_poller/pull/129)
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
+
+gem 'rufus-scheduler', ENV['RUFUS_SCHEDULER_VERSION'] if ENV['RUFUS_SCHEDULER_VERSION']

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -163,13 +163,12 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     #schedule hash must contain exactly one of the allowed keys
     msg_invalid_schedule = "Invalid config. schedule hash must contain " +
       "exactly one of the following keys - cron, at, every or in"
-    raise Logstash::ConfigurationError, msg_invalid_schedule if @schedule.keys.length !=1
+    raise Logstash::ConfigurationError, msg_invalid_schedule if @schedule.keys.length != 1
     schedule_type = @schedule.keys.first
     schedule_value = @schedule[schedule_type]
     raise LogStash::ConfigurationError, msg_invalid_schedule unless Schedule_types.include?(schedule_type)
 
     @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
-    #as of v3.0.9, :first_in => :now doesn't work. Use the following workaround instead
     opts = schedule_type == "every" ? { :first_in => 0.01 } : {} 
     @scheduler.send(schedule_type, schedule_value, opts) { run_once(queue) }
     @scheduler.join

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -55,8 +55,14 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     setup_requests!
   end
 
+  # @overload
   def stop
-    @scheduler.stop if @scheduler
+    @scheduler.shutdown(:wait) if @scheduler
+  end
+
+  # @overload
+  def close
+    @scheduler.shutdown if @scheduler
   end
 
   private

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -58,11 +58,13 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   # @overload
   def stop
     @scheduler.shutdown(:wait) if @scheduler
+    close_client!
   end
 
   # @overload
   def close
     @scheduler.shutdown if @scheduler
+    close_client!
   end
 
   private
@@ -196,6 +198,25 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     client.async.send(method, *request_opts).
       on_success {|response| handle_success(queue, name, request, response, Time.now - started) }.
       on_failure {|exception| handle_failure(queue, name, request, exception, Time.now - started) }
+  end
+
+  def close_client!
+    ObjectSpace.undefine_finalizer client # avoid leaking - waiting for runtime shutdown!
+
+    finalizers = client.instance_variable_get :@finalizers
+    finalizers.each do |obj, args|
+      begin
+        obj.send(*args) if obj.weakref_alive?
+      rescue => e
+        logger.debug "failed to #{args.first} http client resource: #{obj}", exception: e.class, message: e.message
+      end
+    end
+
+    begin
+      client.close
+    rescue => e
+      logger.warn "failed while closing http client", exception: e.class, message: e.message
+    end
   end
 
   private

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -176,7 +176,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
     opts = schedule_type == "every" ? { :first_in => 0.01 } : {} 
     @scheduler.send(schedule_type, schedule_value, opts) { run_once(queue) }
-    @scheduler.join
+    @scheduler.thread.join
   end
 
   def run_once(queue)

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -57,7 +57,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   # @overload
   def stop
-    if @scheduler && @scheduler.thread && @scheduler.thread.status
+    if @scheduler
       @scheduler.shutdown # on newer Rufus (3.8) this joins on the scheduler thread
     end
     # TODO implement client.close as we as releasing it's pooled resources!

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -68,9 +68,8 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   def shutdown_scheduler_and_release_client(opt = nil)
     if @scheduler
       @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
-      thread = @scheduler.thread
-      thread.wakeup if thread && thread.status == 'sleep'
     end
+    # TODO implement client.close as we as releasing it's pooled resources!
   end
   private :shutdown_scheduler_and_release_client
 

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -57,21 +57,11 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   # @overload
   def stop
-    shutdown_scheduler_and_release_client
-  end
-
-  # @overload
-  def close
-    shutdown_scheduler_and_release_client(:kill)
-  end
-
-  def shutdown_scheduler_and_release_client(opt = nil)
-    if @scheduler
-      @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
+    if @scheduler && @scheduler.thread && @scheduler.thread.status
+      @scheduler.shutdown # on newer Rufus (3.8) this joins on the scheduler thread
     end
     # TODO implement client.close as we as releasing it's pooled resources!
   end
-  private :shutdown_scheduler_and_release_client
 
   private
   def setup_requests!

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -56,7 +56,6 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
   end
 
   def stop
-    Stud.stop!(@interval_thread) if @interval_thread
     @scheduler.stop if @scheduler
   end
 

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -57,15 +57,23 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
 
   # @overload
   def stop
-    @scheduler.shutdown(:wait) if @scheduler
-    close_client!
+    shutdown_scheduler_and_release_client
   end
 
   # @overload
   def close
-    @scheduler.shutdown if @scheduler
+    shutdown_scheduler_and_release_client(:kill)
+  end
+
+  def shutdown_scheduler_and_release_client(opt = nil)
+    if @scheduler
+      @scheduler.shutdown(opt) # on newer Rufus (3.8) this joins on the scheduler thread
+      thread = @scheduler.thread
+      thread.wakeup if thread && thread.status == 'sleep'
+    end
     close_client!
   end
+  private :shutdown_scheduler_and_release_client
 
   private
   def setup_requests!

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -178,7 +178,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
     opts = schedule_type == "every" ? { :first_in => 0.01 } : {} 
     @scheduler.send(schedule_type, schedule_value, opts) { run_once(queue) }
-    @scheduler.thread.join
+    @scheduler.join
   end
 
   def run_once(queue)

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -178,7 +178,7 @@ class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
     @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
     opts = schedule_type == "every" ? { :first_in => 0.01 } : {} 
     @scheduler.send(schedule_type, schedule_value, opts) { run_once(queue) }
-    @scheduler.join
+    @scheduler.thread.join # due newer rufus (3.8) doing a blocking operation on scheduler.join
   end
 
   def run_once(queue)

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-mixin-http_client', "~> 7"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
-  s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
+  s.add_runtime_dependency 'rufus-scheduler', ">= 3.0.9"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-mixin-http_client', "~> 7"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
-  s.add_runtime_dependency 'rufus-scheduler', ">= 3.0.9"
+  s.add_runtime_dependency 'rufus-scheduler', "~> 3.0.9"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-mixin-http_client', "~> 7"
   s.add_runtime_dependency 'stud', "~> 0.0.22"
-  s.add_runtime_dependency 'rufus-scheduler', "~> 3.0.9"
+  s.add_runtime_dependency 'rufus-scheduler', ">= 3.0.9"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'logstash-mixin-http_client', "~> 7"
-  s.add_runtime_dependency 'stud', "~> 0.0.22"
   s.add_runtime_dependency 'rufus-scheduler', ">= 3.0.9"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version         = '5.1.0'
+  s.version     = '5.1.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version     = '5.1.0'
+  s.version     = '5.1.1'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -25,7 +25,8 @@ describe LogStash::Inputs::HTTP_Poller do
       "schedule" => default_schedule,
       "urls" => default_urls,
       "codec" => "json",
-      "metadata_target" => metadata_target
+      "metadata_target" => metadata_target,
+      "pool_max" => 3, "pool_max_per_route" => 1, 'keepalive' => false
     }
   }
   let(:opts) { default_opts }

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -550,6 +550,8 @@ describe LogStash::Inputs::HTTP_Poller do
 
   describe "stopping" do
     let(:config) { default_opts }
-    it_behaves_like "an interruptible input plugin"
+    it_behaves_like "an interruptible input plugin" do
+      let(:allowed_lag) { 10 } # CI: wait till scheduler shuts down
+    end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -572,12 +572,13 @@ describe LogStash::Inputs::HTTP_Poller do
       subject.do_stop
       sleep 2.5
 
-      if plugin_thread.alive?
+      #if plugin_thread.alive?
         require 'jruby'
         runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.raw_thread_dump
+        puts runtime.thread_dump
         puts '-' * 150
-      end
+        puts runtime.raw_thread_dump
+      #end
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
@@ -585,7 +586,7 @@ describe LogStash::Inputs::HTTP_Poller do
         try(10) { expect(plugin_thread).to_not be_alive }
       ensure
         # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        # puts runtime.thread_dump
+        # puts runtime.raw_thread_dump
       end
     end
   end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -189,21 +189,28 @@ describe LogStash::Inputs::HTTP_Poller do
           "metadata_target" => metadata_target
         }
       }
+
+      before do
+        Timecop.travel(Time.new(2000,1,1,0,0,0,'+00:00'))
+        Timecop.scale(60)
+      end
+
+      after do
+        Timecop.return
+      end
+
       it "should run at the schedule" do
         instance = klass.new(opts)
         instance.register
-        Timecop.travel(Time.new(2000,1,1,0,0,0,'+00:00'))
-        Timecop.scale(60)
+
         queue = Queue.new
         runner = Thread.new do
           instance.run(queue)
         end
         sleep 3
         instance.stop
-        runner.kill
         runner.join
         expect(queue.size).to eq(2)
-        Timecop.return
       end
     end
 
@@ -216,21 +223,28 @@ describe LogStash::Inputs::HTTP_Poller do
           "metadata_target" => metadata_target
         }
       }
+
+      before do
+        Timecop.travel(Time.new(2000,1,1,0,0,0,'+00:00'))
+        Timecop.scale(60 * 5)
+      end
+
+      after do
+        Timecop.return
+      end
+
       it "should run at the schedule" do
         instance = klass.new(opts)
         instance.register
-        Timecop.travel(Time.new(2000,1,1,0,0,0,'+00:00'))
-        Timecop.scale(60 * 5)
+
         queue = Queue.new
         runner = Thread.new do
           instance.run(queue)
         end
         sleep 2
         instance.stop
-        runner.kill
         runner.join
         expect(queue.size).to eq(1)
-        Timecop.return
       end
     end
 
@@ -255,7 +269,6 @@ describe LogStash::Inputs::HTTP_Poller do
         #expects 3 events at T=5
         sleep 5
         instance.stop
-        runner.kill
         runner.join
         expect(queue.size).to be_between(2, 3)
       end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -247,7 +247,7 @@ describe LogStash::Inputs::HTTP_Poller do
           #T       0123456
           #events  x x x x
           #expects 3 events at T=5
-          expect(queue.size).to be_between(2, 3)
+          try(3) { expect(queue.size).to be_between(2, 3) }
         end
       end
     end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -571,7 +571,7 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 4 } # 8.1 shutting down slower with newer Rufus
+      let(:allowed_lag) { 5 } # 8.1 shutting down slower with newer Rufus
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -202,15 +202,17 @@ describe LogStash::Inputs::HTTP_Poller do
       it "should run at the schedule" do
         instance = klass.new(opts)
         instance.register
-
         queue = Queue.new
-        runner = Thread.new do
-          instance.run(queue)
+        begin
+          runner = Thread.new do
+            instance.run(queue)
+          end
+          sleep 3
+          try(3) { expect(queue.size).to eq(2) }
+        ensure
+          instance.stop
+          runner.join if runner
         end
-        sleep 3
-        instance.stop
-        runner.join
-        try(3) { expect(queue.size).to eq(2) }
       end
     end
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -551,7 +551,7 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 10 } # CI: wait till scheduler shuts down
+      let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -571,7 +571,7 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 5 } # 8.1 shutting down slower with newer Rufus
+      let(:allowed_lag) { 10 } # 8.1 shutting down slower with newer Rufus
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -35,9 +35,8 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "instances" do
     subject { described_class.new(default_opts) }
 
-    before do
-      subject.register
-    end
+    before { subject.register }
+    after { subject.stop }
 
     describe "#run" do
       it "should setup a scheduler" do
@@ -336,6 +335,8 @@ describe LogStash::Inputs::HTTP_Poller do
           allow(poller).to receive(:handle_success)
           event # materialize the subject
         end
+
+        after { poller.stop }
 
         it "should enqueue a message" do
           expect(event).to be_a(LogStash::Event)

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -568,7 +568,16 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      try(10) { sleep(1.0); expect(plugin_thread).to_not be_alive }
+
+      require 'jruby'
+      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
+      puts runtime.thread_dump
+      puts '-' * 150
+
+      try(10) { expect(plugin_thread).to_not be_alive }
+      if plugin_thread.alive?
+        puts runtime.thread_dump
+      end
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,19 +570,22 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
+      sleep 1.5
 
-      require 'jruby'
-      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-      puts runtime.thread_dump
-      puts '-' * 150
+      if plugin_thread.alive?
+        require 'jruby'
+        runtime = org.jruby.management.Runtime.new(JRuby.runtime)
+        puts runtime.thread_dump
+        puts '-' * 150
+      end
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
       begin
         try(10) { expect(plugin_thread).to_not be_alive }
       ensure
-        puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        puts runtime.thread_dump
+        # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+        # puts runtime.thread_dump
       end
     end
   end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -556,26 +556,4 @@ describe LogStash::Inputs::HTTP_Poller do
       let(:allowed_lag) { 10 } # CI: wait till scheduler shuts down
     end
   end
-
-  describe "closing" do
-    let(:config) { default_opts.merge "schedule" => '* * * * *' }
-
-    let(:queue) { SizedQueue.new(20) }
-    before(:each) do
-      subject.register
-    end
-
-    it "returns from run" do
-      Thread.start(queue) { |queue| loop { queue.pop } }
-      plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
-      # the run method is a long lived one, so it should still be running after "a bit"
-      sleep 0.5
-      try(5) { expect(plugin_thread).to be_alive }
-
-      subject.do_close
-      sleep 2.5
-
-      try(10) { expect(plugin_thread).to_not be_alive }
-    end
-  end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -574,10 +574,12 @@ describe LogStash::Inputs::HTTP_Poller do
       puts runtime.thread_dump
       puts '-' * 150
 
+      puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+
       try(10) { expect(plugin_thread).to_not be_alive }
-      if plugin_thread.alive?
-        puts runtime.thread_dump
-      end
+
+      puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+      puts runtime.thread_dump
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,8 +570,6 @@ describe LogStash::Inputs::HTTP_Poller do
 
   describe "stopping" do
     let(:config) { default_opts }
-    it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 120 } # TODO 8.1 shutting down slower with newer Rufus
-    end
+    it_behaves_like "an interruptible input plugin"
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -578,12 +578,10 @@ describe LogStash::Inputs::HTTP_Poller do
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
-      begin
-        try(10) { expect(plugin_thread).to_not be_alive }
-      ensure
-        puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        puts runtime.thread_dump
-      end
+      try(10) { expect(plugin_thread).to_not be_alive }
+
+      puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+      puts runtime.thread_dump
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -572,13 +572,12 @@ describe LogStash::Inputs::HTTP_Poller do
       subject.do_stop
       sleep 2.5
 
-      #if plugin_thread.alive?
+      if plugin_thread.alive?
         require 'jruby'
         runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.thread_dump
-        puts '-' * 150
         puts runtime.raw_thread_dump
-      #end
+        puts '-' * 150
+      end
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
@@ -586,7 +585,7 @@ describe LogStash::Inputs::HTTP_Poller do
         try(10) { expect(plugin_thread).to_not be_alive }
       ensure
         # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        # puts runtime.raw_thread_dump
+        # puts runtime.thread_dump
       end
     end
   end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -576,12 +576,10 @@ describe LogStash::Inputs::HTTP_Poller do
       puts runtime.thread_dump
       puts '-' * 150
 
-      puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-
       try(10) { expect(plugin_thread).to_not be_alive }
-
-      puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-      puts runtime.thread_dump
+      if plugin_thread.alive?
+        puts runtime.thread_dump
+      end
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,16 +570,7 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-
-      require 'jruby'
-      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-      puts runtime.thread_dump
-      puts '-' * 150
-
-      try(10) { expect(plugin_thread).to_not be_alive }
-      if plugin_thread.alive?
-        puts runtime.thread_dump
-      end
+      try(10) { sleep(1.0); expect(plugin_thread).to_not be_alive }
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -202,7 +202,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       it "should run at the schedule" do
         run_plugin_and_yield_queue(plugin, sleep: 3) do |queue|
-          try(10) { expect(queue.size).to eq(2) }
+          try(5) { expect(queue.size).to be >= 2 }
         end
       end
     end
@@ -219,7 +219,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       before do
         Timecop.travel(Time.new(2000,1,1,0,0,0,'+00:00'))
-        Timecop.scale(60 * 5)
+        Timecop.scale (60 * 5) / 2
       end
 
       after do

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -210,7 +210,7 @@ describe LogStash::Inputs::HTTP_Poller do
         sleep 3
         instance.stop
         runner.join
-        expect(queue.size).to eq(2)
+        try(3) { expect(queue.size).to eq(2) }
       end
     end
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,22 +570,19 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      sleep 1.5
 
-      if plugin_thread.alive?
-        require 'jruby'
-        runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.thread_dump
-        puts '-' * 150
-      end
+      require 'jruby'
+      runtime = org.jruby.management.Runtime.new(JRuby.runtime)
+      puts runtime.thread_dump
+      puts '-' * 150
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
       begin
         try(10) { expect(plugin_thread).to_not be_alive }
       ensure
-        # puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-        # puts runtime.thread_dump
+        puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+        puts runtime.thread_dump
       end
     end
   end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,12 +570,12 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      sleep 2.5
+      sleep 1.5
 
       if plugin_thread.alive?
         require 'jruby'
         runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.raw_thread_dump
+        puts runtime.thread_dump
         puts '-' * 150
       end
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -553,7 +553,29 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
+      let(:allowed_lag) { 10 } # CI: wait till scheduler shuts down
+    end
+  end
+
+  describe "closing" do
+    let(:config) { default_opts.merge "schedule" => '* * * * *' }
+
+    let(:queue) { SizedQueue.new(20) }
+    before(:each) do
+      subject.register
+    end
+
+    it "returns from run" do
+      Thread.start(queue) { |queue| loop { queue.pop } }
+      plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
+      # the run method is a long lived one, so it should still be running after "a bit"
+      sleep 0.5
+      try(5) { expect(plugin_thread).to be_alive }
+
+      subject.do_close
+      sleep 2.5
+
+      try(10) { expect(plugin_thread).to_not be_alive }
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,12 +570,12 @@ describe LogStash::Inputs::HTTP_Poller do
       try(5) { expect(plugin_thread).to be_alive }
       # now let's actually stop the plugin
       subject.do_stop
-      sleep 1.5
+      sleep 2.5
 
       if plugin_thread.alive?
         require 'jruby'
         runtime = org.jruby.management.Runtime.new(JRuby.runtime)
-        puts runtime.thread_dump
+        puts runtime.raw_thread_dump
         puts '-' * 150
       end
 

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -551,26 +551,9 @@ describe LogStash::Inputs::HTTP_Poller do
   end
 
   describe "stopping" do
-    # let(:config) { default_opts }
-    # it_behaves_like "an interruptible input plugin" do
-    #   let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
-    # end
-
-    let(:queue) { SizedQueue.new(20) }
-    before(:each) do
-      subject.register
-      java.lang.System.gc
-    end
-
-    it "returns from run" do
-      Thread.start(queue) { |queue| loop { queue.pop } }
-      plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
-      # the run method is a long lived one, so it should still be running after "a bit"
-      sleep 0.5
-      try(5) { expect(plugin_thread).to be_alive }
-      # now let's actually stop the plugin
-      subject.do_stop
-      try(10) { sleep(1.0); expect(plugin_thread).to_not be_alive }
+    let(:config) { default_opts }
+    it_behaves_like "an interruptible input plugin" do
+      let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -549,9 +549,26 @@ describe LogStash::Inputs::HTTP_Poller do
   end
 
   describe "stopping" do
-    let(:config) { default_opts }
-    it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
+    # let(:config) { default_opts }
+    # it_behaves_like "an interruptible input plugin" do
+    #   let(:allowed_lag) { 20 } # CI: wait till scheduler shuts down
+    # end
+
+    let(:queue) { SizedQueue.new(20) }
+    before(:each) do
+      subject.register
+      java.lang.System.gc
+    end
+
+    it "returns from run" do
+      Thread.start(queue) { |queue| loop { queue.pop } }
+      plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
+      # the run method is a long lived one, so it should still be running after "a bit"
+      sleep 0.5
+      try(5) { expect(plugin_thread).to be_alive }
+      # now let's actually stop the plugin
+      subject.do_stop
+      try(10) { sleep(1.0); expect(plugin_thread).to_not be_alive }
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -576,10 +576,12 @@ describe LogStash::Inputs::HTTP_Poller do
 
       puts "1PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
 
-      try(10) { expect(plugin_thread).to_not be_alive }
-
-      puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
-      puts runtime.thread_dump
+      begin
+        try(10) { expect(plugin_thread).to_not be_alive }
+      ensure
+        puts "2PLUGIN THREAD alive? : #{plugin_thread.alive?.inspect}"
+        puts runtime.thread_dump
+      end
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -202,7 +202,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       it "should run at the schedule" do
         run_plugin_and_yield_queue(plugin, sleep: 3) do |queue|
-          try(3) { expect(queue.size).to eq(2) }
+          try(10) { expect(queue.size).to eq(2) }
         end
       end
     end
@@ -228,7 +228,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       it "should run at the schedule" do
         run_plugin_and_yield_queue(plugin, sleep: 2) do |queue|
-          try(3) { expect(queue.size).to eq(1) }
+          try(5) { expect(queue.size).to eq(1) }
         end
       end
     end
@@ -247,7 +247,7 @@ describe LogStash::Inputs::HTTP_Poller do
           #T       0123456
           #events  x x x x
           #expects 3 events at T=5
-          try(3) { expect(queue.size).to be_between(2, 3) }
+          try(5) { expect(queue.size).to be_between(2, 3) }
         end
       end
     end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -277,9 +277,11 @@ describe LogStash::Inputs::HTTP_Poller do
         runner = Thread.new do
           instance.run(queue)
         end
-        sleep 3
+        try(3) do
+          sleep(3)
+          expect(queue.size).to eq(1)
+        end
         instance.stop
-        runner.kill
         runner.join
         expect(queue.size).to eq(1)
       end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -557,6 +557,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
   describe "stopping" do
     let(:config) { default_opts }
+    let(:allowed_lag) { 4 } # 8.1 shutting down slower with newer Rufus
     it_behaves_like "an interruptible input plugin"
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -571,7 +571,7 @@ describe LogStash::Inputs::HTTP_Poller do
   describe "stopping" do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
-      let(:allowed_lag) { 10 } # 8.1 shutting down slower with newer Rufus
+      let(:allowed_lag) { 120 } # TODO 8.1 shutting down slower with newer Rufus
     end
   end
 end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -570,7 +570,8 @@ describe LogStash::Inputs::HTTP_Poller do
 
   describe "stopping" do
     let(:config) { default_opts }
-    let(:allowed_lag) { 4 } # 8.1 shutting down slower with newer Rufus
-    it_behaves_like "an interruptible input plugin"
+    it_behaves_like "an interruptible input plugin" do
+      let(:allowed_lag) { 4 } # 8.1 shutting down slower with newer Rufus
+    end
   end
 end


### PR DESCRIPTION
Removing dependency lock (see https://github.com/elastic/logstash/issues/12931):
```patch
-  s.add_runtime_dependency 'rufus-scheduler', "~>3.0.9"
+  s.add_runtime_dependency 'rufus-scheduler', ">= 3.0.9"
```

~~CI :red_circle: happens after the unpinning but is likely related to https://github.com/elastic/logstash/issues/13572~~

The :red_circle: CI does reproduce sporadically locally but most of the time running Dockers as well as non-Docker `rspec` is :green_circle: on CI, since the new ubuntu base image, it fails pretty much all the time.

There's a separate investigation going on at https://github.com/logstash-plugins/logstash-input-http_poller/pull/130 (this PR was crafted from the other one thus commits are a bit verbose but the changelog is mostly around refactoring tests here). Also, please note the added target to keep testing against `3.0.9` it's failing the same and confirms the issue is not related to the scheduler upgrade. 

There some test changes included (to make sure scheduler is always shutdown between tests).