### PR TITLE
Add ssl_enabled option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.0
+  - Added new `ssl_enabled` setting for enabling/disabling the SSL configurations [#143](https://github.com/logstash-plugins/logstash-input-http_poller/pull/143)
+
 ## 5.5.1
  - [DOC]Remove redundant table items [#142](https://github.com/logstash-plugins/logstash-input-http_poller/pull/142)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.6.0
-  - Added new `ssl_enabled` setting for enabling/disabling the SSL configurations [#143](https://github.com/logstash-plugins/logstash-input-http_poller/pull/143)
+  - Added new `ssl_enabled` setting for enabling/disabling the SSL configurations [#146](https://github.com/logstash-plugins/logstash-input-http_poller/pull/146)
 
 ## 5.5.1
  - [DOC]Remove redundant table items [#142](https://github.com/logstash-plugins/logstash-input-http_poller/pull/142)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -149,6 +149,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |list of <<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_path>> |<<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_keystore_type>> |<<string,string>>|No
@@ -454,6 +455,15 @@ The .cer or .pem CA files to validate the server's certificate.
 
 The list of cipher suites to use, listed by priorities.
 Supported cipher suites vary depending on the Java and protocol versions.
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+Enable SSL/TLS secured communication. It must be `true` for other `ssl_` options
+to take effect.
 
 [id="plugins-{type}s-{plugin}-ssl_key"]
 ===== `ssl_key`

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version     = '5.5.1'
+  s.version     = '5.6.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.3.0", "< 8.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.4.0", "< 8.0.0"
   s.add_runtime_dependency 'logstash-mixin-scheduler', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'


### PR DESCRIPTION
Added support to the `ssl_enabled` option by bumping the `logstash-mixin-http_client` ([logstash-mixin-http_client/pull/44](https://github.com/logstash-plugins/logstash-mixin-http_client/pull/44)), making it compliant with the [Logstash SSL Standardisation](https://github.com/elastic/logstash/issues/14905).

---
Closes: https://github.com/logstash-plugins/logstash-input-http_poller/issues/145