### PR TITLE
Mark previously deprecated SSL settings as obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     - `truststore`, which should be replaced by `ssl_truststore_path>`
     - `truststore_password`, which should be replaced by `ssl_truststore_password`
     - `truststore_type`, which should be replaced by `ssl_truststore_type`
-    - [#xxx](https://github.com/logstash-plugins/logstash-input-http_poller/pull/xxx)
+    - [#149](https://github.com/logstash-plugins/logstash-input-http_poller/pull/149)
 
 ## 5.6.0
   - Added new `ssl_enabled` setting for enabling/disabling the SSL configurations [#146](https://github.com/logstash-plugins/logstash-input-http_poller/pull/146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 6.0.0
+  - SSL settings that were marked deprecated in version `5.6.0` are now marked obsolete, and will prevent the plugin from starting.
+  - These settings are:
+    - `cacert`, which should be replaced by `ssl_certificate_authorities`
+    - `client_cert`, which should be replaced by `ssl_certificate`
+    - `client_key`, which should be replaced by `ssl_key`
+    - `keystore`, which should be replaced by `ssl_keystore_path`
+    - `keystore_password`, which should be replaced by `ssl_keystore_password`
+    - `keystore_type`, which should be replaced by `ssl_keystore_password`
+    - `truststore`, which should be replaced by `ssl_truststore_path>`
+    - `truststore_password`, which should be replaced by `ssl_truststore_password`
+    - `truststore_type`, which should be replaced by `ssl_truststore_type`
+    - [#xxx](https://github.com/logstash-plugins/logstash-input-http_poller/pull/xxx)
+
 ## 5.6.0
   - Added new `ssl_enabled` setting for enabling/disabling the SSL configurations [#146](https://github.com/logstash-plugins/logstash-input-http_poller/pull/146)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -122,21 +122,19 @@ Here’s how ECS compatibility mode affects output.
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
+NOTE: As of version `6.0.0` of this plugin, a number of previously deprecated settings related to SSL have been removed.
+Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
+
+
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-automatic_retries>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-cacert>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-client_cert>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-client_key>> |a valid filesystem path|__Deprecated__
 | <<plugins-{type}s-{plugin}-connect_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-cookies>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-follow_redirects>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-keepalive>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-keystore>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-keystore_password>> |<<password,password>>|__Deprecated__
-| <<plugins-{type}s-{plugin}-keystore_type>> |<<string,string>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-metadata_target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-pool_max>> |<<number,number>>|No
@@ -158,9 +156,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_truststore_type>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>, one of `["full", "none"]`|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-truststore>> |a valid filesystem path|__Deprecated__
-| <<plugins-{type}s-{plugin}-truststore_password>> |<<password,password>>|__Deprecated__
-| <<plugins-{type}s-{plugin}-truststore_type>> |<<string,string>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-urls>> |<<hash,hash>>|Yes
 | <<plugins-{type}s-{plugin}-user>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-validate_after_inactivity>> |<<number,number>>|No
@@ -180,33 +175,6 @@ input plugins.
 How many times should the client retry a failing URL. We highly recommend NOT setting this value
 to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry!
 Note: if `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
-
-[id="plugins-{type}s-{plugin}-cacert"]
-===== `cacert` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you need to use a custom X.509 CA (.pem certs) specify the path to that here
-
-[id="plugins-{type}s-{plugin}-client_cert"]
-===== `client_cert` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_certificate>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you'd like to use a client certificate (note, most people don't want this) set the path to the x509 cert here
-
-[id="plugins-{type}s-{plugin}-client_key"]
-===== `client_key` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_key>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you're using a client certificate specify the path to the encryption key here
 
 [id="plugins-{type}s-{plugin}-connect_timeout"]
 ===== `connect_timeout` 
@@ -316,34 +284,6 @@ Should redirects be followed? Defaults to `true`
 
 Turn this on to enable HTTP keepalive support. We highly recommend setting `automatic_retries` to at least
 one with this to fix interactions with broken keepalive implementations.
-
-[id="plugins-{type}s-{plugin}-keystore"]
-===== `keystore` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_path>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you need to use a custom keystore (`.jks`) specify that here. This does not work with .pem keys!
-
-[id="plugins-{type}s-{plugin}-keystore_password"]
-===== `keystore_password` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_password>>]
-
-  * Value type is <<password,password>>
-  * There is no default value for this setting.
-
-Specify the keystore password here.
-Note, most .jks files created with keytool require a password!
-
-[id="plugins-{type}s-{plugin}-keystore_type"]
-===== `keystore_type` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_keystore_type>>]
-
-  * Value type is <<string,string>>
-  * Default value is `"JKS"`
-
-Specify the keystore type here. One of `JKS` or `PKCS12`. Default is `JKS`
 
 [id="plugins-{type}s-{plugin}-metadata_target"]
 ===== `metadata_target` 
@@ -569,35 +509,6 @@ Define the target field for placing the received data. If this setting is omitte
 TIP: When ECS is enabled, set `target` in the codec (if the codec has a `target` option).
 Example: `codec => json { target => "TARGET_FIELD_NAME" }`
 
-
-[id="plugins-{type}s-{plugin}-truststore"]
-===== `truststore` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_path>>]
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-If you need to use a custom truststore (`.jks`) specify that here. This does not work with .pem certs!
-
-[id="plugins-{type}s-{plugin}-truststore_password"]
-===== `truststore_password` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_password>>]
-
-  * Value type is <<password,password>>
-  * There is no default value for this setting.
-
-Specify the truststore password here.
-Note, most .jks files created with keytool require a password!
-
-[id="plugins-{type}s-{plugin}-truststore_type"]
-===== `truststore_type` 
-deprecated[5.5.0, Replaced by <<plugins-{type}s-{plugin}-ssl_truststore_type>>]
-
-  * Value type is <<string,string>>
-  * Default value is `"JKS"`
-
-Specify the truststore type here. One of `JKS` or `PKCS12`. Default is `JKS`
-
 [id="plugins-{type}s-{plugin}-urls"]
 ===== `urls` 
 
@@ -662,6 +573,28 @@ milliseconds after which persistent connections must be re-validated prior to
 being leased to the consumer. Non-positive value passed to this method disables
 connection validation. This check helps detect connections that have become
 stale (half-closed) while kept inactive in the pool."
+
+
+[id="plugins-{type}s-{plugin}-obsolete-options"]
+==== HTTP Poller Input Obsolete Configuration Options
+
+WARNING: As of version `6.0.0` of this plugin, some configuration options have been replaced.
+The plugin will fail to start if it contains any of these obsolete options.
+
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| cacert |<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| client_cert |<<plugins-{type}s-{plugin}-ssl_certificate>>
+| client_key |<<plugins-{type}s-{plugin}-ssl_key>>
+| keystore |<<plugins-{type}s-{plugin}-ssl_keystore_path>>
+| keystore_password |<<plugins-{type}s-{plugin}-ssl_keystore_password>>
+| keystore_type |<<plugins-{type}s-{plugin}-ssl_keystore_password>>
+| truststore |<<plugins-{type}s-{plugin}-ssl_truststore_path>>
+| truststore_password |<<plugins-{type}s-{plugin}-ssl_truststore_password>>
+| truststore_type |<<plugins-{type}s-{plugin}-ssl_truststore_type>>
+|=======================================================================
+
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/inputs/http_poller.rb
+++ b/lib/logstash/inputs/http_poller.rb
@@ -11,7 +11,7 @@ require 'logstash/plugin_mixins/event_support/event_factory_adapter'
 require 'logstash/plugin_mixins/scheduler'
 
 class LogStash::Inputs::HTTP_Poller < LogStash::Inputs::Base
-  include LogStash::PluginMixins::HttpClient[:with_deprecated => true]
+  include LogStash::PluginMixins::HttpClient[:with_obsolete => true]
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
   include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
   include LogStash::PluginMixins::EventSupport::EventFactoryAdapter

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version     = '5.6.0'
+  s.version     = '6.0.0'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.4.0", "< 8.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 7.5.0", "< 8.0.0"
   s.add_runtime_dependency 'logstash-mixin-scheduler', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0', '>= 1.0.1'

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -219,7 +219,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       before do
         Timecop.travel(Time.new(2000,1,1,0,0,0,'+00:00'))
-        Timecop.scale (60)
+        Timecop.scale (60 * 5) / 2
       end
 
       after do
@@ -228,7 +228,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       it "should run at the schedule" do
         run_plugin_and_yield_queue(plugin, sleep: 4.1) do |queue|
-          try(30) { expect(queue.size).to eq(1) }
+          try(10) { expect(queue.size).to eq(1) }
         end
       end
     end

--- a/spec/inputs/http_poller_spec.rb
+++ b/spec/inputs/http_poller_spec.rb
@@ -210,7 +210,7 @@ describe LogStash::Inputs::HTTP_Poller do
     context "given 'at' expression" do
       let(:opts) {
         {
-          "schedule" => { "at" => "2000-01-01 00:05:00 +0000"},
+          "schedule" => { "at" => "2000-01-01 00:15:00 +0000"},
           "urls" => default_urls,
           "codec" => "json",
           "metadata_target" => metadata_target
@@ -219,7 +219,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       before do
         Timecop.travel(Time.new(2000,1,1,0,0,0,'+00:00'))
-        Timecop.scale (60 * 5) / 2
+        Timecop.scale (60)
       end
 
       after do
@@ -228,7 +228,7 @@ describe LogStash::Inputs::HTTP_Poller do
 
       it "should run at the schedule" do
         run_plugin_and_yield_queue(plugin, sleep: 4.1) do |queue|
-          try(10) { expect(queue.size).to eq(1) }
+          try(30) { expect(queue.size).to eq(1) }
         end
       end
     end
@@ -555,6 +555,36 @@ describe LogStash::Inputs::HTTP_Poller do
     let(:config) { default_opts }
     it_behaves_like "an interruptible input plugin" do
       let(:allowed_lag) { 10 } # CI: wait till scheduler shuts down
+    end
+  end
+
+  describe "obsolete settings" do
+    let(:default_url) { "http://localhost:2322" }
+    let(:config) {
+      {
+        "schedule" => { "cron" => "0 0 0 0 0 UTC" },
+        "urls" => default_urls,
+        "codec" => "json"
+      }
+    }
+    [{:name => 'cacert', :canonical_name => 'ssl_certificate_authorities'},
+     {:name => 'client_cert', :canonical_name => 'ssl_certificate'},
+     {:name => 'client_key', :canonical_name => 'ssl_key'},
+     {:name => "keystore", :canonical_name => 'ssl_keystore_path'},
+     {:name => 'truststore', :canonical_name => 'ssl_truststore_path'},
+     {:name => "keystore_password", :canonical_name => "ssl_keystore_password"},
+     {:name => 'truststore_password', :canonical_name => "ssl_truststore_password"},
+     {:name => "keystore_type", :canonical_name => "ssl_keystore_type"},
+     {:name => 'truststore_type', :canonical_name => 'ssl_truststore_type'}
+    ].each do |settings|
+      context "with option #{settings[:name]}" do
+        let(:obsolete_config) { config.merge(settings[:name] => 'test_value') }
+
+        it "emits an error about the setting `#{settings[:name]}` now being obsolete and provides guidance to use `#{settings[:canonical_name]}`" do
+          error_text = /The setting `#{settings[:name]}` in plugin `http_poller` is obsolete and is no longer available. Use `#{settings[:canonical_name]}` instead/i
+          expect { LogStash::Inputs::HTTP_Poller.new(obsolete_config)}.to raise_error LogStash::ConfigurationError, error_text
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- SSL settings that were marked deprecated in version `5.6.0` are now marked obsolete, and will prevent the plugin from starting.
- These settings are:
  - `cacert`, which should be replaced by `ssl_certificate_authorities`
  - `client_cert`, which should be replaced by `ssl_certificate`
  - `client_key`, which should be replaced by `ssl_key`
  - `keystore`, which should be replaced by `ssl_keystore_path`
  - `keystore_password`, which should be replaced by `ssl_keystore_password`
  - `keystore_type`, which should be replaced by `ssl_keystore_password`
  - `truststore`, which should be replaced by `ssl_truststore_path>`
  - `truststore_password`, which should be replaced by `ssl_truststore_password`
  - `truststore_type`, which should be replaced by `ssl_truststore_type`

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
