### PR TITLE
prepare release 5.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.1
+  - Fix issue with new 'uri' gem leading to runtime exception [#148](https://github.com/logstash-plugins/logstash-input-http_poller/pull/148)
+
 ## 5.6.0
   - Added new `ssl_enabled` setting for enabling/disabling the SSL configurations [#146](https://github.com/logstash-plugins/logstash-input-http_poller/pull/146)
 

--- a/logstash-input-http_poller.gemspec
+++ b/logstash-input-http_poller.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'logstash-input-http_poller'
-  s.version     = '5.6.0'
+  s.version     = '5.6.1'
   s.licenses    = ['Apache License (2.0)']
   s.summary     = "Decodes the output of an HTTP API into events"
   s.description = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
commit https://github.com/logstash-plugins/logstash-input-http_poller/commit/b0c82dc7d781915b436a7ad13529859b84c88c93 was never released in a 5.6.x release, this PR will fix it.