### PR TITLE
Stop special casing tests for stack version 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,2 @@
 import:
   - logstash-plugins/.ci:travis/travis.yml@1.x
-
-jobs:
-  exclude:
-  - env: ELASTIC_STACK_VERSION=7.current
-  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=7.current
-  include:
-  - env: ELASTIC_STACK_VERSION=7.current RUFUS_SCHEDULER_VERSION=3.0.9 SNAPSHOT=true
-  - env: ELASTIC_STACK_VERSION=7.current RUFUS_SCHEDULER_VERSION=3.0.9


### PR DESCRIPTION
With logstash-plugins/.ci#106 there is no need to be special casing for version 7.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
